### PR TITLE
Removes unnecessary imports for FourierFlows.jl ≥ v0.6.17

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.5
+          version: 1.6
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.5
+          version: 1.6
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ version = "0.5.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FourierFlows = "2aec4490-903f-5c70-9b11-9bed06a700e1"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -17,6 +18,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 CUDA = "^1.3, ^2, ^3"
+DocStringExtensions = "^0.8"
 FourierFlows = "^0.6.17, ^0.7"
 JLD2 = "^0.1, ^0.2, ^0.3, ^0.4"
 Reexport = "^0.2, ^1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,10 @@ license = "MIT"
 authors = ["Navid C. Constantinou <navidcy@gmail.com>", "Gregory L. Wagner <wagner.greg@gmail.com>"]
 documentation = "https://fourierflows.github.io/PassiveTracerFlowsDocumentation/dev/"
 repository = "https://github.com/FourierFlows/PassiveTracerFlows.jl"
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FourierFlows = "2aec4490-903f-5c70-9b11-9bed06a700e1"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -18,8 +17,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 CUDA = "^1.3, ^2, ^3"
-FFTW = "^1"
-FourierFlows = "^0.6.17"
+FourierFlows = "^0.6.17, ^0.7"
 JLD2 = "^0.1, ^0.2, ^0.3, ^0.4"
 Reexport = "^0.2, ^1"
 julia = "^1.5"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ See `examples/` for example scripts.
 
 The code is citable via [zenodo](https://zenodo.org). Please cite as:
 
-> Navid C. Constantinou. and Gregory L. Wagner (2021). FourierFlows/PassiveTracerFlows.jl: PassiveTracerFlows v0.5.0 (Version v0.5.0). Zenodo.  [https://doi.org/10.5281/zenodo.2535983](https://doi.org/10.5281/zenodo.2535983)
+> Navid C. Constantinou. and Gregory L. Wagner (2021). FourierFlows/PassiveTracerFlows.jl: PassiveTracerFlows v0.5.1 (Version v0.5.1). Zenodo.  [https://doi.org/10.5281/zenodo.2535983](https://doi.org/10.5281/zenodo.2535983)
 
 [FourierFlows.jl]: https://github.com/FourierFlows/FourierFlows.jl

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-FourierFlows = "2aec4490-903f-5c70-9b11-9bed06a700e1"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 PassiveTracerFlows = "dc26d6a1-c8d5-50f2-8a17-f57a5c578a00"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,5 +6,4 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-FourierFlows = "≥ 0.6.17"
 Plots = "≥ 1.10.1"

--- a/examples/cellularflow.jl
+++ b/examples/cellularflow.jl
@@ -45,17 +45,15 @@ nothing # hide
 # ## Set up cellular flow
 # We create a two-dimensional grid to construct the cellular flow. Our cellular flow is derived
 # from a streamfunction ``ψ(x, y) = ψ₀ \cos(x) \cos(y)`` as ``(u, v) = (-∂_y ψ, ∂_x ψ)``.
-
 grid = TwoDGrid(n, L)
-x, y = gridpoints(grid)
 
 ψ₀ = 0.2
 mx, my = 1, 1
 
-ψ = @. ψ₀ * cos(mx * x) * cos(my * y)
+ψ = @. ψ₀ * cos(mx * grid.x) * cos(my * grid.y)
 
-uvel(x, y) =  ψ₀ * mx * cos(mx * x) * sin(my * y)
-vvel(x, y) = -ψ₀ * my * sin(mx * x) * cos(my * y)
+uvel(x, y) =  ψ₀ * my * cos(mx * x) * sin(my * y)
+vvel(x, y) = -ψ₀ * mx * sin(mx * x) * cos(my * y)
 nothing # hide
 
 

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -5,7 +5,9 @@ export
    set_c!,
    updatevars!
 
-using Reexport
+using
+   DocStringExtensions,
+   Reexport
 
 @reexport using FourierFlows
 
@@ -55,37 +57,64 @@ abstract type AbstractConstDiffParams <: AbstractParams end
 abstract type AbstractSteadyFlowParams <: AbstractParams end
 
 """
-    ConstDiffParams(η, κ, κh, nκh, u, v)
-    ConstDiffParams(η, κ, u, v)
+    struct ConstDiffParams{T} <: AbstractConstDiffParams
 
-Returns the params for constant diffusivity problem with time-varying flow.
+A struct containing the parameters for a constant diffusivity problem with time-varying flow.
+Included are:
+
+$(TYPEDFIELDS)
 """
 struct ConstDiffParams{T} <: AbstractConstDiffParams
-  η :: T           # Constant isotropic horizontal diffusivity
-  κ :: T           # Constant isotropic vertical diffusivity
- κh :: T           # Constant isotropic hyperdiffusivity
-nκh :: Int         # Constant isotropic hyperdiffusivity order
-  u :: Function    # Advecting x-velocity
-  v :: Function    # Advecting y-velocity
+    "isotropic horizontal diffusivity coefficient"
+       η :: T
+    "isotropic vertical diffusivity coefficient"
+       κ :: T
+    "isotropic hyperdiffusivity coefficient"
+      κh :: T
+    "isotropic hyperdiffusivity order"  
+     nκh :: Int
+    "function returning the x-component of advecting flow"
+       u :: Function
+    "function returning the y-component of advecting flow"
+       v :: Function
 end
 
+"""
+    ConstDiffParams(η, κ, u, v)
+
+The constructor for the `params` struct for constant diffusivity problem and time-varying flow.
+"""
 ConstDiffParams(η, κ, u, v) = ConstDiffParams(η, κ, 0η, 0, u, v)
 
 """
-    ConstDiffSteadyFlowParams(η, κ, κh, nκh, u, v, g)
-    ConstDiffSteadyFlowParams(η, κ, u, v, g)
+    struct ConstDiffParams{T} <: AbstractConstDiffParams
 
-Returns the params for constant diffusivity problem with time-steady flow.
+A struct containing the parameters for a constant diffusivity problem with steady flow.
+Included are:
+
+$(TYPEDFIELDS)
 """
 struct ConstDiffSteadyFlowParams{T,A} <: AbstractSteadyFlowParams
-  η :: T           # Constant horizontal diffusivity
-  κ :: T           # Constant vertical diffusivity
- κh :: T           # Constant isotropic hyperdiffusivity
-nκh :: Int         # Constant isotropic hyperdiffusivity order
-  u :: A           # Advecting x-velocity
-  v :: A           # Advecting y-velocity
+  "isotropic horizontal diffusivity coefficient"
+     η :: T
+  "isotropic vertical diffusivity coefficient"
+     κ :: T
+  "isotropic hyperdiffusivity coefficient"
+    κh :: T
+  "isotropic hyperdiffusivity order"  
+   nκh :: Int
+   "x-component of advecting flow"
+      u :: A
+   "x-component of advecting flow"
+      v :: A
 end
 
+"""
+    ConstDiffSteadyFlowParams(η, κ, κh, nκh, u::Function, v::Function, grid)
+    ConstDiffSteadyFlowParams(η, κ, u, v, grid)
+
+The constructor for the `params` struct for constant diffusivity problem and steady flow.
+"""
 function ConstDiffSteadyFlowParams(η, κ, κh, nκh, u::Function, v::Function, grid)
    x, y = gridpoints(grid)
   ugrid = u.(x, y)
@@ -102,7 +131,7 @@ ConstDiffSteadyFlowParams(η, κ, u, v, grid) = ConstDiffSteadyFlowParams(η, κ
 # --
 
 """
-    Equation(p, g)
+    Equation(params, grid)
 
 Returns the equation for constant diffusivity problem with params p and grid g.
 """
@@ -123,19 +152,32 @@ end
 # Vars
 # --
 
+"""
+    struct Vars{Aphys, Atrans} <: AbstractVars
+
+The variables for TracerAdvectionDiffussion problems.
+
+$(FIELDS)
+"""
 struct Vars{Aphys, Atrans} <: AbstractVars
-    c :: Aphys
-   cx :: Aphys
-   cy :: Aphys
-   ch :: Atrans
-  cxh :: Atrans
-  cyh :: Atrans
+    "tracer concentration"
+       c :: Aphys
+    "tracer concentration x-derivative, ∂c/∂x"
+      cx :: Aphys
+    "tracer concentration y-derivative, ∂c/∂y"
+      cy :: Aphys
+    "Fourier transform of tracer concentration"
+      ch :: Atrans
+    "Fourier transform of tracer concentration x-derivative, ∂c/∂x"
+     cxh :: Atrans
+    "Fourier transform of tracer concentration y-derivative, ∂c/∂y"
+     cyh :: Atrans
 end
 
 """
-    Vars(g)
+    Vars(dev, grid)
 
-Returns the vars for constant diffusivity problem on grid g.
+Returns the variables `vars` for a constant diffusivity problem on `grid` and device `dev`.
 """
 function Vars(::Dev, grid::AbstractGrid{T}) where {Dev, T}
   @devzeros Dev T (grid.nx, grid.ny) c cx cy

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -5,9 +5,7 @@ export
    set_c!,
    updatevars!
 
-using
-  FFTW,
-  Reexport
+using Reexport
 
 @reexport using FourierFlows
 

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -105,7 +105,7 @@ struct ConstDiffSteadyFlowParams{T,A} <: AbstractSteadyFlowParams
    nκh :: Int
    "x-component of advecting flow"
       u :: A
-   "x-component of advecting flow"
+   "y-component of advecting flow"
       v :: A
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,17 +1,14 @@
 using
-  CUDA,
-  FourierFlows,
+  PassiveTracerFlows,
   Test,
   Statistics,
-  Random,
-  FFTW
+  Random
 
 import # use 'import' rather than 'using' for submodules to keep namespace clean
   PassiveTracerFlows.TracerAdvectionDiffusion
 
 # the devices on which tests will run
-devices = (CPU(),)
-@has_cuda devices = (CPU(), GPU())
+devices = CUDA.has_cuda() ? (CPU(), GPU()) : (CPU(),)
 
 const rtol_traceradvectiondiffusion = 1e-12 # tolerance for rtol_traceradvdiff tests
 

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -18,7 +18,8 @@ function test_constvel(stepper, dt, nsteps, dev::Device=CPU())
   x, y = gridpoints(gr)
 
   σ = 0.1
-  c0func(x, y) = 0.1*exp(-(x^2+y^2)/(2σ^2))
+  c0ampl = 0.1
+  c0func(x, y) = c0ampl * exp(-(x^2+y^2)/(2σ^2))
 
   c0 = c0func.(x, y)
   tfinal = nsteps*dt


### PR DESCRIPTION
This PR makes some necessary updates to the package to deal with minor API changes in FourierFlows.jl 0.7.

Also, the PR enhances the `TracerAdvectionDiffusion` module docstrings.