### PR TITLE
Add 1D advection-diffusion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,8 +19,8 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 CUDA = "^1.3, ^2, ^3"
-DocStringExtensions = "^0.8"
-FourierFlows = "^0.6.17, ^0.7, 0.8, 0.9"
+DocStringExtensions = "0.8, 0.9"
+FourierFlows = "0.9.2"
 GeophysicalFlows = "0.14"
 JLD2 = "^0.1, ^0.2, ^0.3, ^0.4"
 Reexport = "^0.2, ^1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ license = "MIT"
 authors = ["Navid C. Constantinou <navidcy@gmail.com>", "Gregory L. Wagner <wagner.greg@gmail.com>"]
 documentation = "https://fourierflows.github.io/PassiveTracerFlowsDocumentation/dev/"
 repository = "https://github.com/FourierFlows/PassiveTracerFlows.jl"
-version = "0.6.1"
+version = "0.7.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ See `examples/` for example scripts.
 
 The code is citable via [zenodo](https://zenodo.org). Please cite as:
 
-> Navid C. Constantinou. and Gregory L. Wagner (2022). FourierFlows/PassiveTracerFlows.jl: PassiveTracerFlows v0.6.1 (Version v0.6.1). Zenodo.  [https://doi.org/10.5281/zenodo.2535983](https://doi.org/10.5281/zenodo.2535983)
+> Navid C. Constantinou, Josef Bisits, and Gregory L. Wagner (2022). FourierFlows/PassiveTracerFlows.jl: PassiveTracerFlows v0.7.0 (Version v0.7.0). Zenodo. [https://doi.org/10.5281/zenodo.2535983](https://doi.org/10.5281/zenodo.2535983)
 
 [FourierFlows.jl]: https://github.com/FourierFlows/FourierFlows.jl

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,7 @@ const EXAMPLES_DIR = joinpath(@__DIR__, "..", "examples")
 const OUTPUT_DIR   = joinpath(@__DIR__, "src/literated")
 
 examples = [
+    "onedim_gaussiandiff.jl"
     "cellularflow.jl",
     "turbulent_advection-diffusion.jl"
 ]
@@ -56,6 +57,7 @@ makedocs(
            "Home" => "index.md",
            "Examples" => Any[
              "TracerAdvectionDiffusion" => Any[
+               "literated/onedim_gaussiandiff.md",
                "literated/cellularflow.md",
                "literated/turbulent_advection-diffusion.md",
                ]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -57,7 +57,7 @@ makedocs(
            "Home" => "index.md",
            "Examples" => Any[
              "TracerAdvectionDiffusion" => Any[
-               "literated/onedim_gaussiandifusionf.md",
+               "literated/onedim_gaussiandiffusion.md",
                "literated/cellularflow.md",
                "literated/turbulent_advection-diffusion.md",
                ]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -57,7 +57,7 @@ makedocs(
            "Home" => "index.md",
            "Examples" => Any[
              "TracerAdvectionDiffusion" => Any[
-               "literated/onedim_gaussiandiff.md",
+               "literated/onedim_gaussiandifusionf.md",
                "literated/cellularflow.md",
                "literated/turbulent_advection-diffusion.md",
                ]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,7 +17,7 @@ const EXAMPLES_DIR = joinpath(@__DIR__, "..", "examples")
 const OUTPUT_DIR   = joinpath(@__DIR__, "src/literated")
 
 examples = [
-    "onedim_gaussiandiff.jl",
+    "onedim_gaussiandiffusion.jl",
     "cellularflow.jl",
     "turbulent_advection-diffusion.jl"
 ]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,7 +17,7 @@ const EXAMPLES_DIR = joinpath(@__DIR__, "..", "examples")
 const OUTPUT_DIR   = joinpath(@__DIR__, "src/literated")
 
 examples = [
-    "onedim_gaussiandiff.jl"
+    "onedim_gaussiandiff.jl",
     "cellularflow.jl",
     "turbulent_advection-diffusion.jl"
 ]

--- a/examples/cellularflow.jl
+++ b/examples/cellularflow.jl
@@ -62,8 +62,7 @@ nothing # hide
 
 # ## Problem setup
 # We initialize a `Problem` by providing a set of keyword arguments.
-prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx=n, Lx=L, κ=κ,
-                                          dt=dt, stepper=stepper)
+prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx=n, Lx=L, κ, dt, stepper)
 nothing # hide
 
 # and define some shortcuts

--- a/examples/cellularflow.jl
+++ b/examples/cellularflow.jl
@@ -60,7 +60,7 @@ nothing # hide
 
 # ## Problem setup
 # We initialize a `Problem` by providing a set of keyword arguments.
-prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx=n, Lx=L, κ=κ, steadyflow=true, u=uvel, v=vvel,
+prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx=n, Lx=L, κ=κ, steadyflow=true,
                                           dt=dt, stepper=stepper)
 nothing # hide
 

--- a/examples/cellularflow.jl
+++ b/examples/cellularflow.jl
@@ -54,12 +54,13 @@ mx, my = 1, 1
 
 uvel(x, y) =  ψ₀ * my * cos(mx * x) * sin(my * y)
 vvel(x, y) = -ψ₀ * mx * sin(mx * x) * cos(my * y)
+advecting_flow = (u = uvel, v = vvel)
 nothing # hide
 
 
 # ## Problem setup
 # We initialize a `Problem` by providing a set of keyword arguments.
-prob = TracerAdvectionDiffusion.Problem(dev; nx=n, Lx=L, κ=κ, steadyflow=true, u=uvel, v=vvel,
+prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx=n, Lx=L, κ=κ, steadyflow=true, u=uvel, v=vvel,
                                           dt=dt, stepper=stepper)
 nothing # hide
 

--- a/examples/cellularflow.jl
+++ b/examples/cellularflow.jl
@@ -45,6 +45,8 @@ nothing # hide
 # ## Set up cellular flow
 # We create a two-dimensional grid to construct the cellular flow. Our cellular flow is derived
 # from a streamfunction ``ψ(x, y) = ψ₀ \cos(x) \cos(y)`` as ``(u, v) = (-∂_y ψ, ∂_x ψ)``.
+# The celluar flow is then passed into the `TwoDAdvectingFlow` constructor with `steadyflow = true`
+# to indicate that the flow is not time dependent.
 grid = TwoDGrid(n, L)
 
 ψ₀ = 0.2
@@ -54,13 +56,13 @@ mx, my = 1, 1
 
 uvel(x, y) =  ψ₀ * my * cos(mx * x) * sin(my * y)
 vvel(x, y) = -ψ₀ * mx * sin(mx * x) * cos(my * y)
-advecting_flow = (u = uvel, v = vvel)
+advecting_flow = TwoDAdvectingFlow(; u = uvel, v = vvel, steadyflow = true)
 nothing # hide
 
 
 # ## Problem setup
 # We initialize a `Problem` by providing a set of keyword arguments.
-prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx=n, Lx=L, κ=κ, steadyflow=true,
+prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx=n, Lx=L, κ=κ,
                                           dt=dt, stepper=stepper)
 nothing # hide
 

--- a/examples/onedim_gaussiandiffusion.jl
+++ b/examples/onedim_gaussiandiffusion.jl
@@ -1,0 +1,129 @@
+# # Advection-diffusion of tracer in one dimension
+#
+# This is an example demonstrating the advection-diffusion of a passive tracer in 
+# one dimension. 
+#
+# ## Install dependencies
+#
+# First let's make sure we have all the required packages installed
+
+# ```julia
+# using Pkg
+# pkg.add(["PassiveTracerFlows", "Printf", "Plots", "JLD2"])
+# ```
+#
+# ## Let's begin
+# First load packages needed to run this example.
+using PassiveTracerFlows, Printf, JLD2, LinearAlgebra
+
+# ## Choosing a device: CPU or GPU
+
+dev = CPU()     # Device (CPU/GPU)
+nothing # hide
+
+
+# ## Numerical parameters and time-stepping parameters
+
+      n = 128            # 2D resolution = n²
+stepper = "RK4"          # timestepper
+     dt = 0.02           # timestep
+ nsteps = 5000            # total number of time-steps
+nothing # hide
+
+
+# ## Physical parameters
+
+L = 2π        # domain size
+κ = 0.01     # diffusivity
+nothing # hide
+
+# ## Flow
+# We set a constant background flow. Note this is stil done using a `Function` 
+uvel(x) = 0.05
+#uvel_t(x, t) = log(1 + t / 2500) an example of flow increasing with time
+
+# ## Problem setup
+# We initialize a `Problem` by providing a set of keyword arguments.
+prob = TracerAdvectionDiffusion.Problem(dev, true; nx=n, Lx=L, κ=κ, steadyflow=false, u=uvel_t,
+                                          dt=dt, stepper=stepper)
+nothing # hide
+
+# and define some shortcuts
+sol, clock, vars, params, grid = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+x = grid.x
+
+# ## Initial condition
+# We will advect-diffuse a concentration field that has an initial concentration set to Gaussian.
+gaussian(x, σ) = exp(-(x^2) / (2σ^2))
+
+amplitude, spread = 1, 0.15
+c₀ = [amplitude * gaussian(x[i], spread) for i=1:grid.nx]
+
+TracerAdvectionDiffusion.set_c!(prob, c₀)
+nothing #hide
+
+# ## Saving output
+# We will create the saved output using the `Output` function from `FourierFlows.jl` then
+# save the concentration field using the `get_concentration` function every 50 timesteps.
+function get_concentration(prob)
+    ldiv!(prob.vars.c, grid.rfftplan,  deepcopy(prob.sol))
+  
+    return prob.vars.c
+end
+  
+output = Output(prob, "advection-diffusion1D.jld2",
+                (:concentration, get_concentration))
+
+# This saves information that we will use for plotting later on
+saveproblem(output)
+
+# ## Stepping the problem forward
+# Now we step the problem forward saving at every 50 timesteps.
+save_frequency = 50 # frequency at which output is saved
+startwalltime = time()
+while clock.step <= nsteps
+  if clock.step % save_frequency == 0
+    saveoutput(output)
+    log = @sprintf("Output saved, step: %04d, t: %.2f, walltime: %.2f min",
+                   clock.step, clock.t, (time()-startwalltime) / 60)
+
+    println(log)
+  end
+
+  stepforward!(prob)
+end
+
+# ## Visualising the output
+# From the saved data we create a timeseries of the concentration field
+file = jldopen(output.path)
+
+iterations = parse.(Int, keys(file["snapshots/t"]))
+t = [file["snapshots/t/$i"] for i ∈ iterations]
+
+c = [file["snapshots/concentration/$i"] for i ∈ iterations]
+
+nothing # hide
+
+# Set up the plotting arguments and look at the initial concentration.
+x, Lx  = file["grid/x"], file["grid/Lx"]
+
+plot_args = (xlabel = "x",
+             ylabel = "c",
+             framestyle = :box,
+             xlims = (-Lx/2, Lx/2),
+             ylims = (0, maximum(c[1])),
+             legend = :false,
+             color = :balance)
+
+p = plot(x, Array(c[1]), title = "concentration, t = " * @sprintf("%.2f", t[1]); plot_args...)
+
+nothing # hide
+
+# Create a movie of the tracer concentration being advected-diffused.
+
+anim = @animate for i ∈ 1:length(t)
+  p[1][:title] = "concentration, t = " * @sprintf("%.2f", t[i])
+  p[1][1][:y] = Array(c[i])
+end
+
+mp4(anim, "1D_advection-diffusion.mp4", fps = 12)

--- a/examples/onedim_gaussiandiffusion.jl
+++ b/examples/onedim_gaussiandiffusion.jl
@@ -38,12 +38,13 @@ L = 2π        # domain size
 nothing # hide
 
 # ## Flow
-# We set a constant background flow. Note this is done using a single `Function` in one dimension.
-advecting_flow = uvel(x) = 0.05
+# We set a constant background flow and pass this to `OneDAdvectingFlow` with `steadyflow = true` to indicate the flow is not time dependent.
+uvel(x) = 0.05
+advecting_flow = OneDAdvectingFlow(; u = uvel, steadyflow = true)
 
 # ## Problem setup
 # We initialize a `Problem` by providing a set of keyword arguments.
-prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx=n, Lx=L, κ=κ, steadyflow=true,
+prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx=n, Lx=L, κ=κ,
                                           dt=dt, stepper=stepper)
 nothing # hide
 

--- a/examples/onedim_gaussiandiffusion.jl
+++ b/examples/onedim_gaussiandiffusion.jl
@@ -40,11 +40,10 @@ nothing # hide
 # ## Flow
 # We set a constant background flow. Note this is stil done using a `Function` 
 uvel(x) = 0.05
-#uvel_t(x, t) = log(1 + t / 2500) an example of flow increasing with time
 
 # ## Problem setup
 # We initialize a `Problem` by providing a set of keyword arguments.
-prob = TracerAdvectionDiffusion.Problem(dev, true; nx=n, Lx=L, κ=κ, steadyflow=false, u=uvel_t,
+prob = TracerAdvectionDiffusion.Problem(dev, true; nx=n, Lx=L, κ=κ, steadyflow=true, u=uvel,
                                           dt=dt, stepper=stepper)
 nothing # hide
 

--- a/examples/onedim_gaussiandiffusion.jl
+++ b/examples/onedim_gaussiandiffusion.jl
@@ -38,12 +38,12 @@ L = 2π        # domain size
 nothing # hide
 
 # ## Flow
-# We set a constant background flow. Note this is stil done using a `Function` 
-uvel(x) = 0.05
+# We set a constant background flow. Note this is done using a single `Function` in one dimension.
+advecting_flow = uvel(x) = 0.05
 
 # ## Problem setup
 # We initialize a `Problem` by providing a set of keyword arguments.
-prob = TracerAdvectionDiffusion.Problem(dev, true; nx=n, Lx=L, κ=κ, steadyflow=true, u=uvel,
+prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx=n, Lx=L, κ=κ, steadyflow=true,
                                           dt=dt, stepper=stepper)
 nothing # hide
 

--- a/examples/onedim_gaussiandiffusion.jl
+++ b/examples/onedim_gaussiandiffusion.jl
@@ -44,8 +44,7 @@ advecting_flow = OneDAdvectingFlow(; u = uvel, steadyflow = true)
 
 # ## Problem setup
 # We initialize a `Problem` by providing a set of keyword arguments.
-prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx=n, Lx=L, κ=κ,
-                                          dt=dt, stepper=stepper)
+prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx=n, Lx=L, κ, dt, stepper)
 nothing # hide
 
 # and define some shortcuts

--- a/examples/onedim_gaussiandiffusion.jl
+++ b/examples/onedim_gaussiandiffusion.jl
@@ -14,7 +14,7 @@
 #
 # ## Let's begin
 # First load packages needed to run this example.
-using PassiveTracerFlows, Printf, JLD2, LinearAlgebra
+using PassiveTracerFlows, Plots, Printf, JLD2, LinearAlgebra
 
 # ## Choosing a device: CPU or GPU
 

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -72,7 +72,7 @@ function Problem(dev, advecting_flow::NamedTuple=(u=noflow, v=noflow);
 end
 
 """
-    Problem(dev, MQGprob; parameters...)
+    Problem(dev, MQGprob::FourierFlows.Problem; parameters...)
 
 Construct a constant diffusivity problem on device `dev` using the flow from a
 `GeophysicalFlows.MultiLayerQG` problem.

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -216,7 +216,7 @@ end
 The constructor for the `params` struct for constant diffusivity problem and steady flow.
 """
 function ConstDiffSteadyFlowParams(κ, κh, nκh, u::Function, grid::OneDGrid)
-    x = grid.x
+    x = ArrayType(dev)([gr.x[i] for i ∈ 1:gr.nx])
    ugrid = u.(x)
    
    return ConstDiffSteadyFlowParams1D(κ, κh, nκh, ugrid)

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -43,7 +43,7 @@ steadyflow = false,
 )
 
 grid = OneDGrid(dev, nx, Lx; T=T)
-params = steadyflow==true ? ConstDiffSteadyFlowParams(κ, u, grid::OneDGrid) : ConstDiffTimeVaryingFlowParams(κ, u)
+params = steadyflow==true ? ConstDiffSteadyFlowParams(κ, u, grid::OneDGrid, dev) : ConstDiffTimeVaryingFlowParams(κ, u)
 vars = Vars(dev, grid; T=T)
 equation = Equation(dev, params, grid)
 
@@ -215,14 +215,14 @@ end
 
 The constructor for the `params` struct for constant diffusivity problem and steady flow.
 """
-function ConstDiffSteadyFlowParams(κ, κh, nκh, u::Function, grid::OneDGrid)
-    x = ArrayType(dev)([gr.x[i] for i ∈ 1:gr.nx])
+function ConstDiffSteadyFlowParams(κ, κh, nκh, u::Function, grid::OneDGrid, dev)
+    x = ArrayType(dev)([grid.x[i] for i ∈ 1:grid.nx])
    ugrid = u.(x)
    
    return ConstDiffSteadyFlowParams1D(κ, κh, nκh, ugrid)
  end
  
- ConstDiffSteadyFlowParams(κ, u, grid::OneDGrid) = ConstDiffSteadyFlowParams(κ, 0κ, 0, u, grid)
+ ConstDiffSteadyFlowParams(κ, u, grid::OneDGrid, dev) = ConstDiffSteadyFlowParams(κ, 0κ, 0, u, grid, dev)
 
 function ConstDiffSteadyFlowParams(η, κ, κh, nκh, u::Function, v::Function, grid::TwoDGrid)
    x, y = gridpoints(grid)

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -30,14 +30,14 @@ abstract type AbstractAdvectingFlow end
     struct OneDAdvectingFlow <: AbstractAdvectingFlow
 
 A struct containing the advecting flow for a one dimensional `TracerAdvectionDiffusion.Problem`.
-Included is
+Included are
 
 $(TYPEDFIELDS)
 """
 struct OneDAdvectingFlow <: AbstractAdvectingFlow
-    "Function for the x-component of the advecting flow"
+    "function for the x-component of the advecting flow"
              u :: Function
-    "Whether or not the flow is steady (i.e., not time dependent)"
+    "boolean declaring whether or not the flow is steady (i.e., not time dependent)"
     steadyflow :: Bool
 end
 
@@ -55,16 +55,16 @@ OneDAdvectingFlow(; u=noflow, steadyflow=true) = OneDAdvectingFlow(u, steadyflow
     struct TwoDAdvectingFlow <: AbstractAdvectingFlow
 
 A struct containing the advecting flow for a two dimensional `TracerAdvectionDiffusion.Problem`.
-Included is
+Included are
 
 $(TYPEDFIELDS)
 """
 struct TwoDAdvectingFlow <: AbstractAdvectingFlow
-    "Function for the x-component of the advecting flow"
+    "function for the x-component of the advecting flow"
              u :: Function
-    "Function for the y-component of the advecting flow"
+    "function for the y-component of the advecting flow"
              v :: Function
-    "Whether or not the flow is steady (i.e., not time dependent)"
+    "boolean declaring whether or not the flow is steady (i.e., not time dependent)"
     steadyflow :: Bool
 end
 
@@ -83,8 +83,8 @@ TwoDAdvectingFlow(; u=noflow, v=noflow, steadyflow=true) = TwoDAdvectingFlow(u, 
 """
     Problem(dev, advecting_flow; parameters...)
 
-Construct a constant diffusivity problem with steady or time-varying flow. The dimensionality
-of the problem is inferred from the `advecting_flow`:
+Construct a constant diffusivity problem with steady or time-varying `advecting_flow` on device `dev`.
+The dimensionality of the problem is inferred from the `advecting_flow`:
 * `advecting_flow::OneDAdvectingFlow` for 1D advection-diffusion problem,
 * `advecting_flow::TwoDAdvectingFlow` for 2D advection-diffusion problem.
 """
@@ -139,7 +139,7 @@ end
     Problem(dev, MQGprob::FourierFlows.Problem; parameters...)
 
 Construct a constant diffusivity problem on device `dev` using the flow from a
-`GeophysicalFlows.MultiLayerQG` problem.
+`GeophysicalFlows.MultiLayerQG` problem as the advecting flow.
 """
 function Problem(dev, MQGprob::FourierFlows.Problem;
                      κ = 0.1,
@@ -177,8 +177,8 @@ abstract type AbstractTurbulentFlowParams <: AbstractParams end
 """
     struct ConstDiffTimeVaryingFlowParams1D{T} <: AbstractTimeVaryingFlowParams
 
-A struct containing the parameters for a constant diffusivity problem with time-varying flow in one dimension.
-Included are:
+A struct containing the parameters for a constant diffusivity problem with time-varying flow in one
+dimension. Included are:
 
 $(TYPEDFIELDS)
 """
@@ -196,8 +196,8 @@ end
 """
     struct ConstDiffTimeVaryingFlowParams2D{T} <: AbstractTimeVaryingFlowParams
 
-A struct containing the parameters for a constant diffusivity problem with time-varying flow in two dimensions.
-Included are:
+A struct containing the parameters for a constant diffusivity problem with time-varying flow in two
+dimensions. Included are:
 
 $(TYPEDFIELDS)
 """
@@ -273,7 +273,7 @@ end
     ConstDiffSteadyFlowParams(η, κ, κh, nκh, u::Function, v::Function, grid::TwoDGrid)
     ConstDiffSteadyFlowParams(η, κ, u, v, grid::TwoDGrid)
 
-The constructor for the `params` struct for constant diffusivity problem and steady flow.
+Return the parameters `params` for a constant diffusivity problem and steady flow.
 """
 function ConstDiffSteadyFlowParams(κ, κh, nκh, u::Function, grid::OneDGrid)
    x = gridpoints(grid)
@@ -322,7 +322,7 @@ end
 """
     ConstDiffTurbulentFlowParams(η, κ, tracer_release_time, MQGprob)
 
-The constructor for the `params` for a constant diffusivity problem with flow obtained
+Return the parameters `params` for a constant diffusivity problem with flow obtained
 from a `GeophysicalFlows.MultiLayerQG` problem.
 """
 function ConstDiffTurbulentFlowParams(η, κ, tracer_release_time, MQGprob)
@@ -387,58 +387,56 @@ end
 """
     struct Vars1D{Aphys, Atrans} <: AbstractVars
 
-The variables for a 1D TracerAdvectionDiffussion problem.
+The variables for a 1D `TracerAdvectionDiffussion` problem.
 
 $(FIELDS)
 """
 struct Vars1D{Aphys, Atrans} <: AbstractVars
     "tracer concentration"
        c :: Aphys
-    "tracer concentration x-derivative, ∂c/∂x"
+    "tracer concentration ``x``-derivative, ``∂c/∂x``"
       cx :: Aphys
     "Fourier transform of tracer concentration"
       ch :: Atrans
-    "Fourier transform of tracer concentration x-derivative, ∂c/∂x"
+    "Fourier transform of tracer concentration ``x``-derivative, ``∂c/∂x``"
      cxh :: Atrans
 end
 
 """
     struct Vars2D{Aphys, Atrans} <: AbstractVars
 
-The variables for a 2D TracerAdvectionDiffussion problem.
+The variables for a 2D `TracerAdvectionDiffussion` problem.
 
 $(FIELDS)
 """
 struct Vars2D{Aphys, Atrans} <: AbstractVars
     "tracer concentration"
        c :: Aphys
-    "tracer concentration x-derivative, ∂c/∂x"
+    "tracer concentration ``x``-derivative, ``∂c/∂x``"
       cx :: Aphys
-    "tracer concentration y-derivative, ∂c/∂y"
+    "tracer concentration ``y``-derivative, ``∂c/∂y``"
       cy :: Aphys
     "Fourier transform of tracer concentration"
       ch :: Atrans
-    "Fourier transform of tracer concentration x-derivative, ∂c/∂x"
+    "Fourier transform of tracer concentration ``x``-derivative, ``∂c/∂x``"
      cxh :: Atrans
-    "Fourier transform of tracer concentration y-derivative, ∂c/∂y"
+    "Fourier transform of tracer concentration ``y``-derivative, ``∂c/∂y``"
      cyh :: Atrans
 end
 
 """
-    Vars(dev, grid)
+    Vars(dev, grid; T=Float64) 
 
 Return the variables `vars` for a constant diffusivity problem on `grid` and device `dev`.
 """
-function Vars(::Dev, grid::OneDGrid; T=Float64) where {Dev}
-
+function Vars(::Dev, grid::OneDGrid; T=Float64) where Dev
     @devzeros Dev T (grid.nx) c cx
     @devzeros Dev Complex{T} (grid.nkr) ch cxh
     
     return Vars1D(c, cx, ch, cxh)
 end
 
-function Vars(::Dev, grid::TwoDGrid; T=Float64) where {Dev}
-
+function Vars(::Dev, grid::TwoDGrid; T=Float64) where Dev
   @devzeros Dev T (grid.nx, grid.ny) c cx cy
   @devzeros Dev Complex{T} (grid.nkr, grid.nl) ch cxh cyh
   
@@ -566,7 +564,7 @@ end
 """
     updatevars!(params::AbstractTurbulentFlowParams, vars, grid, sol)
 
-Update the `vars`` on the `grid` with the solution in `sol` for a problem `prob`
+Update the `vars` on the `grid` with the solution in `sol` for a problem `prob`
 that is being advected by a turbulent flow.     
 """
 function updatevars!(params::AbstractTurbulentFlowParams, vars, grid, sol)  

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -22,7 +22,8 @@ import GeophysicalFlows.MultiLayerQG
 # --
 
 """
-    Problem(; parameters...)
+    Problem(dev::DEV, advecting_flow::Function; parameters...)
+    Problem(dev, advecting_flow::NamedTuple=(u=noflow, v=noflow); parameters...)
 
 Construct a constant diffusivity problem with steady or time-varying flow in one or two
 dimensions.
@@ -31,17 +32,17 @@ One dimension
 """
 noflow(args...) = 0.0 # used as defaults for u, v functions in Problem()
 
-function Problem(dev, onedim::Bool;
+function Problem(dev, advecting_flow::Function;
     nx = 128,
     Lx = 2π,
      κ = 0.1,
-     u = noflow,
     dt = 0.01,
 stepper = "RK4",
 steadyflow = false,
      T = Float64
 )
 
+u = advecting_flow
 grid = OneDGrid(dev, nx, Lx; T=T)
 params = steadyflow==true ? ConstDiffSteadyFlowParams(κ, u, grid::OneDGrid, dev) : ConstDiffTimeVaryingFlowParams(κ, u)
 vars = Vars(dev, grid; T=T)
@@ -52,21 +53,20 @@ end
 """
 Two dimensions
 """
-function Problem(dev;
+function Problem(dev, advecting_flow::NamedTuple=(u=noflow, v=noflow);
           nx = 128,
           Lx = 2π,
           ny = nx,
           Ly = Lx,
            κ = 0.1,
            η = κ,
-           u = noflow,
-           v = noflow,
           dt = 0.01,
      stepper = "RK4",
   steadyflow = false,
            T = Float64
   )
   
+  u, v = advecting_flow
   grid = TwoDGrid(dev, nx, Lx, ny, Ly; T=T)
   params = steadyflow==true ? ConstDiffSteadyFlowParams(η, κ, u, v, grid::TwoDGrid) : ConstDiffTimeVaryingFlowParams(η, κ, u, v)
   vars = Vars(dev, grid; T=T)

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -232,7 +232,7 @@ function ConstDiffSteadyFlowParams(η, κ, κh, nκh, u::Function, v::Function, 
   return ConstDiffSteadyFlowParams2D(η, κ, κh, nκh, ugrid, vgrid)
 end
 
-ConstDiffSteadyFlowParams(η, κ, u, v, grid::OneDGrid) = ConstDiffSteadyFlowParams(η, κ, 0η, 0, u, v, grid)
+ConstDiffSteadyFlowParams(η, κ, u, v, grid::TwoDGrid) = ConstDiffSteadyFlowParams(η, κ, 0η, 0, u, v, grid)
 
 """
     struct ConstDiffTurbulentFlowParams{T} <: AbstractTurbulentFlowParams
@@ -368,7 +368,7 @@ end
 
 Return the variables `vars` for a constant diffusivity problem on `grid` and device `dev`.
 """
-function Vars(::Dev, grid::OneDGrid; T=T) where {Dev}
+function Vars(::Dev, grid::OneDGrid; T=Float64) where {Dev}
 
     @devzeros Dev T (grid.nx) c cx
     @devzeros Dev Complex{T} (grid.nkr) ch cxh
@@ -376,7 +376,7 @@ function Vars(::Dev, grid::OneDGrid; T=T) where {Dev}
     return Vars1D(c, cx, ch, cxh)
 end
 
-function Vars(::Dev, grid::TwoDGrid; T=T) where {Dev}
+function Vars(::Dev, grid::TwoDGrid; T=Float64) where {Dev}
 
   @devzeros Dev T (grid.nx, grid.ny) c cx cy
   @devzeros Dev Complex{T} (grid.nkr, grid.nl) ch cxh cyh

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -27,8 +27,6 @@ import GeophysicalFlows.MultiLayerQG
 
 Construct a constant diffusivity problem with steady or time-varying flow in one or two
 dimensions.
-
-One dimension
 """
 noflow(args...) = 0.0 # used as defaults for u, v functions in Problem()
 
@@ -42,17 +40,15 @@ steadyflow = false,
      T = Float64
 )
 
-u = advecting_flow
-grid = OneDGrid(dev, nx, Lx; T=T)
-params = steadyflow==true ? ConstDiffSteadyFlowParams(κ, u, grid::OneDGrid, dev) : ConstDiffTimeVaryingFlowParams(κ, u)
-vars = Vars(dev, grid; T=T)
-equation = Equation(dev, params, grid)
+  u = advecting_flow
+  grid = OneDGrid(dev, nx, Lx; T=T)
+  params = steadyflow==true ? ConstDiffSteadyFlowParams(κ, u, grid::OneDGrid) : ConstDiffTimeVaryingFlowParams(κ, u)
+  vars = Vars(dev, grid; T=T)
+  equation = Equation(dev, params, grid)
 
-return FourierFlows.Problem(equation, stepper, dt, grid, vars, params, dev)
+  return FourierFlows.Problem(equation, stepper, dt, grid, vars, params, dev)
 end
-"""
-Two dimensions
-"""
+
 function Problem(dev, advecting_flow::NamedTuple=(u=noflow, v=noflow);
           nx = 128,
           Lx = 2π,
@@ -215,14 +211,14 @@ end
 
 The constructor for the `params` struct for constant diffusivity problem and steady flow.
 """
-function ConstDiffSteadyFlowParams(κ, κh, nκh, u::Function, grid::OneDGrid, dev)
-    x = ArrayType(dev)([grid.x[i] for i ∈ 1:grid.nx])
+function ConstDiffSteadyFlowParams(κ, κh, nκh, u::Function, grid::OneDGrid)
+   x = gridpoints(grid)
    ugrid = u.(x)
    
    return ConstDiffSteadyFlowParams1D(κ, κh, nκh, ugrid)
  end
  
- ConstDiffSteadyFlowParams(κ, u, grid::OneDGrid, dev) = ConstDiffSteadyFlowParams(κ, 0κ, 0, u, grid, dev)
+ ConstDiffSteadyFlowParams(κ, u, grid::OneDGrid) = ConstDiffSteadyFlowParams(κ, 0κ, 0, u, grid)
 
 function ConstDiffSteadyFlowParams(η, κ, κh, nκh, u::Function, v::Function, grid::TwoDGrid)
    x, y = gridpoints(grid)

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -524,8 +524,7 @@ updatevars!(prob) = updatevars!(prob.params, prob.vars, prob.grid, prob.sol)
 Set the solution `sol` as the transform of `c` and update variables `vars`.
 """
 function set_c!(sol, params::Union{AbstractTimeVaryingFlowParams, AbstractSteadyFlowParams}, vars, grid, c)
-  C = @CUDA.allowscalar c
-  mul!(sol, grid.rfftplan, C)
+  mul!(sol, grid.rfftplan, c)
   
   updatevars!(params, vars, grid, sol)
   

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -22,7 +22,7 @@ import GeophysicalFlows.MultiLayerQG
 # --
 
 """
-    Problem(dev::DEV, advecting_flow::Function; parameters...)
+    Problem(dev, advecting_flow::Function; parameters...)
     Problem(dev, advecting_flow::NamedTuple=(u=noflow, v=noflow); parameters...)
 
 Construct a constant diffusivity problem with steady or time-varying flow in one or two

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -524,7 +524,8 @@ updatevars!(prob) = updatevars!(prob.params, prob.vars, prob.grid, prob.sol)
 Set the solution `sol` as the transform of `c` and update variables `vars`.
 """
 function set_c!(sol, params::Union{AbstractTimeVaryingFlowParams, AbstractSteadyFlowParams}, vars, grid, c)
-  mul!(sol, grid.rfftplan, c)
+  C = @CUDA.allowscalar c
+  mul!(sol, grid.rfftplan, C)
   
   updatevars!(params, vars, grid, sol)
   

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,9 +25,17 @@ for dev in devices
 
     stepper = "RK4"
     dt, nsteps  = 1e-2, 40
+    @test test_constvel1D(stepper, dt, nsteps, dev)
+    dt, tfinal  = 0.002, 0.1
+    @test test_timedependentvel1D(stepper, dt, tfinal, dev)
+    dt, nsteps  = 1e-2, 40
     @test test_constvel(stepper, dt, nsteps, dev)
     dt, tfinal  = 0.002, 0.1
     @test test_timedependentvel(stepper, dt, tfinal, dev)
+    dt, tfinal  = 0.005, 0.1
+    @test test_diffusion1D(stepper, dt, tfinal, dev; steadyflow=true)
+    dt, tfinal  = 0.005, 0.1
+    @test test_diffusion1D(stepper, dt, tfinal, dev; steadyflow=false)
     dt, tfinal  = 0.005, 0.1
     @test test_diffusion(stepper, dt, tfinal, dev; steadyflow=true)
     dt, tfinal  = 0.005, 0.1

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -14,7 +14,7 @@ function test_constvel1D(stepper, dt, nsteps, dev::Device=CPU())
   prob = TracerAdvectionDiffusion.Problem(dev, true; nx, Lx, κ=0.0, u, dt, stepper, steadyflow=true)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
 
-  x = gr.x
+  x = ArrayType(dev)(gr.x)
 
   σ = 0.1
   c0ampl = 0.1
@@ -52,7 +52,7 @@ function test_timedependentvel1D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 
 
   prob = TracerAdvectionDiffusion.Problem(dev, true; nx, Lx, κ=0.0, u, dt, stepper)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-  x = gr.x
+  x = ArrayType(dev)(gr.x)
 
   σ = 0.2
   c0func(x) = 0.1 * exp(-(x^2) / (2σ^2))
@@ -163,7 +163,7 @@ function test_diffusion1D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
   prob = TracerAdvectionDiffusion.Problem(dev, true; steadyflow=steadyflow, nx=nx,
     Lx=Lx, κ=κ, dt=dt, stepper=stepper)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-  x = gr.x
+  x = ArrayType(dev)(gr.x)
 
   
   c0ampl, σ₀ = 0.1, 0.1

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -13,7 +13,7 @@ function test_constvel1D(stepper, dt, nsteps, dev::Device=CPU())
 
   prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper, steadyflow=true)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-  x = ArrayType(dev)([gr.x[i] for i ∈ 1:gr.nx])
+  x = gridpoints(gr)
 
   σ = 0.1
   c0ampl = 0.1
@@ -51,7 +51,7 @@ function test_timedependentvel1D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 
 
   prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-  x = ArrayType(dev)([gr.x[i] for i ∈ 1:gr.nx])
+  x = gridpoints(gr)
 
   σ = 0.2
   c0func(x) = 0.1 * exp(-(x^2) / (2σ^2))
@@ -166,7 +166,7 @@ function test_diffusion1D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
   prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; steadyflow=steadyflow, nx=nx,
     Lx=Lx, κ=κ, dt=dt, stepper=stepper)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-  x = ArrayType(dev)([gr.x[i] for i ∈ 1:gr.nx])
+  x = gridpoints(gr)
   
   c0ampl, σ₀ = 0.1, 0.1
   σ(t) = sqrt(2κ * t + σ₀)

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -13,8 +13,7 @@ function test_constvel1D(stepper, dt, nsteps, dev::Device=CPU())
 
   prob = TracerAdvectionDiffusion.Problem(dev, true; nx, Lx, κ=0.0, u, dt, stepper, steadyflow=true)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-
-  x = ArrayType(dev)(gr.x)
+  x = ArrayType(dev)(Array(gr.x))
 
   σ = 0.1
   c0ampl = 0.1
@@ -52,7 +51,7 @@ function test_timedependentvel1D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 
 
   prob = TracerAdvectionDiffusion.Problem(dev, true; nx, Lx, κ=0.0, u, dt, stepper)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-  x = ArrayType(dev)(gr.x)
+  x = ArrayType(dev)(Array(gr.x))
 
   σ = 0.2
   c0func(x) = 0.1 * exp(-(x^2) / (2σ^2))
@@ -163,8 +162,7 @@ function test_diffusion1D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
   prob = TracerAdvectionDiffusion.Problem(dev, true; steadyflow=steadyflow, nx=nx,
     Lx=Lx, κ=κ, dt=dt, stepper=stepper)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-  x = ArrayType(dev)(gr.x)
-
+  x = ArrayType(dev)(Array(gr.x))
   
   c0ampl, σ₀ = 0.1, 0.1
   σ(t) = sqrt(2κ * t + σ₀)

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -52,7 +52,7 @@ function test_timedependentvel1D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 
 
   prob = TracerAdvectionDiffusion.Problem(dev, true; nx, Lx, κ=0.0, u, dt, stepper)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-  x = grid.x
+  x = gr.x
 
   σ = 0.2
   c0func(x) = 0.1 * exp(-(x^2) / (2σ^2))
@@ -163,7 +163,7 @@ function test_diffusion1D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
   prob = TracerAdvectionDiffusion.Problem(dev, true; steadyflow=steadyflow, nx=nx,
     Lx=Lx, κ=κ, dt=dt, stepper=stepper)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-  x = grid.x
+  x = gr.x
 
   
   c0ampl, σ₀ = 0.1, 0.1

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -170,6 +170,7 @@ function test_diffusion1D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
   σ(t) = sqrt(2κ * t + σ₀)
   c0func(x, t) = (c0ampl / σ(t)) * exp(-(x^2) / (2 * σ(t)^2))
 
+  c0 = ArrayType(dev)(similar(vs.c))
   c0 = @. c0func(x, 0)
   tfinal = nsteps * dt
   cfinal = @. c0func(x, tfinal)

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -170,8 +170,8 @@ function test_diffusion1D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
   σ(t) = sqrt(2κ * t + σ₀)
   c0func(x, t) = (c0ampl / σ(t)) * exp(-(x^2) / (2 * σ(t)^2))
 
-  c0 = ArrayType(dev)(similar(vs.c))
-  c0 = @. c0func(x, 0)
+  c0 = @. ArrayType(dev)(c0func(x, 0))
+  println(typeof(c0))
   tfinal = nsteps * dt
   cfinal = @. c0func(x, tfinal)
 

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -170,11 +170,12 @@ function test_diffusion1D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
   σ(t) = sqrt(2κ * t + σ₀)
   c0func(x, t) = (c0ampl / σ(t)) * exp(-(x^2) / (2 * σ(t)^2))
 
+  c0 = similar(vs.c)
   c0 = @. c0func(x, 0)
   tfinal = nsteps * dt
   cfinal = @. c0func(x, tfinal)
 
-  TracerAdvectionDiffusion.set_c!(prob, ArrayType(dev)(c0))
+  TracerAdvectionDiffusion.set_c!(prob, c0)
 
   stepforward!(prob, nsteps)
   TracerAdvectionDiffusion.updatevars!(prob)

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -9,9 +9,9 @@ function test_constvel1D(stepper, dt, nsteps, dev::Device=CPU())
 
   nx, Lx = 128, 2π
   uvel = 0.05
-  u(x) = uvel
+  advecting_flow = u(x) = uvel
 
-  prob = TracerAdvectionDiffusion.Problem(dev, true; nx, Lx, κ=0.0, u, dt, stepper, steadyflow=true)
+  prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper, steadyflow=true)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
   x = ArrayType(dev)([gr.x[i] for i ∈ 1:gr.nx])
 
@@ -47,9 +47,9 @@ function test_timedependentvel1D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 
     error("tfinal is not multiple of dt")
   end
   
-  u(x, t) = uvel * t + uvel * dt/2
+  advecting_flow = u(x, t) = uvel * t + uvel * dt/2
 
-  prob = TracerAdvectionDiffusion.Problem(dev, true; nx, Lx, κ=0.0, u, dt, stepper)
+  prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
   x = ArrayType(dev)([gr.x[i] for i ∈ 1:gr.nx])
 
@@ -81,8 +81,9 @@ function test_constvel(stepper, dt, nsteps, dev::Device=CPU())
   uvel, vvel = 0.2, 0.1
   u(x, y) = uvel
   v(x, y) = vvel
+  advecting_flow = (u = u, v = v)
 
-  prob = TracerAdvectionDiffusion.Problem(dev; nx, Lx, κ=0.0, u, v, dt, stepper, steadyflow=true)
+  prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper, steadyflow=true)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
 
   x, y = gridpoints(gr)
@@ -122,8 +123,9 @@ function test_timedependentvel(stepper, dt, tfinal, dev::Device=CPU(); uvel = 0.
   
   u(x, y, t) = uvel
   v(x, y, t) = αv * t + αv * dt/2
+  advecting_flow = (u = u, v = v)
 
-  prob = TracerAdvectionDiffusion.Problem(dev; nx, Lx, κ=0.0, u, v, dt, stepper)
+  prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
   x, y = gridpoints(gr)
 
@@ -159,7 +161,9 @@ function test_diffusion1D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
     error("tfinal is not multiple of dt")
   end
 
-  prob = TracerAdvectionDiffusion.Problem(dev, true; steadyflow=steadyflow, nx=nx,
+  advecting_flow = steadyflow==true ? u(x) = 0.0 : ut(x, t) = 0.0
+
+  prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; steadyflow=steadyflow, nx=nx,
     Lx=Lx, κ=κ, dt=dt, stepper=stepper)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
   x = ArrayType(dev)([gr.x[i] for i ∈ 1:gr.nx])

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -13,7 +13,7 @@ function test_constvel1D(stepper, dt, nsteps, dev::Device=CPU())
 
   prob = TracerAdvectionDiffusion.Problem(dev, true; nx, Lx, κ=0.0, u, dt, stepper, steadyflow=true)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-  x = ArrayType(dev)(Array(gr.x))
+  x = ArrayType(dev)([gr.x[i] for i ∈ 1:gr.nx])
 
   σ = 0.1
   c0ampl = 0.1
@@ -51,7 +51,7 @@ function test_timedependentvel1D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 
 
   prob = TracerAdvectionDiffusion.Problem(dev, true; nx, Lx, κ=0.0, u, dt, stepper)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-  x = ArrayType(dev)(Array(gr.x))
+  x = ArrayType(dev)([gr.x[i] for i ∈ 1:gr.nx])
 
   σ = 0.2
   c0func(x) = 0.1 * exp(-(x^2) / (2σ^2))
@@ -162,7 +162,7 @@ function test_diffusion1D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
   prob = TracerAdvectionDiffusion.Problem(dev, true; steadyflow=steadyflow, nx=nx,
     Lx=Lx, κ=κ, dt=dt, stepper=stepper)
   sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
-  x = ArrayType(dev)(Array(gr.x))
+  x = ArrayType(dev)([gr.x[i] for i ∈ 1:gr.nx])
   
   c0ampl, σ₀ = 0.1, 0.1
   σ(t) = sqrt(2κ * t + σ₀)

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -170,12 +170,11 @@ function test_diffusion1D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
   σ(t) = sqrt(2κ * t + σ₀)
   c0func(x, t) = (c0ampl / σ(t)) * exp(-(x^2) / (2 * σ(t)^2))
 
-  c0 = @. ArrayType(dev)(c0func(x, 0))
-  println(typeof(c0))
+  c0 = @. c0func(x, 0)
   tfinal = nsteps * dt
   cfinal = @. c0func(x, tfinal)
 
-  TracerAdvectionDiffusion.set_c!(prob, c0)
+  TracerAdvectionDiffusion.set_c!(prob, ArrayType(dev)(c0))
 
   stepforward!(prob, nsteps)
   TracerAdvectionDiffusion.updatevars!(prob)

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -170,7 +170,6 @@ function test_diffusion1D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
   σ(t) = sqrt(2κ * t + σ₀)
   c0func(x, t) = (c0ampl / σ(t)) * exp(-(x^2) / (2 * σ(t)^2))
 
-  c0 = similar(vs.c)
   c0 = @. c0func(x, 0)
   tfinal = nsteps * dt
   cfinal = @. c0func(x, tfinal)


### PR DESCRIPTION
This PR adds ability to advect-diffuse in one dimension. I changed `ConstDiffParams` ->  `ConstDiffTimeVaryingFlowParams`. This means that the various parameter structs all now have type that is `ConstDiff...Params` where `...` is the flow specified by the user.

The one dimensional `Problem` is not done in the most elegant way. To use multiple dispatch I added the argument `onedim::Bool` to `Problem`. If either `true` or `false` (not ideal) is passed to `Problem` after `dev` it will setup a 1D `Problem`. Not great I know but I could not think of a better way to do it (without making a new function `Problem1D`). There is an idea I had of how this could be done in a comment further down now..  Any suggestions would be great!  

The `Problem` setup is all the same except now there are `ConstDiffSteadyFlowParams`, `ConstDiffTimeVaryingFlowParams`, and `Vars` in both one and two dimensions. For `Equation` multiple dispatch  based on the `params` is used and for `calcN!`, `calcN!_steadyflow` I used multiple dispatch based on grid type. The `Vars` constructor uses the grid type but when I changed `AbstractGrid{T}` -> `OneDGrid` (or TwoDGrid`) I could not use `OneDGrid{T}` so added the parameter `T`.  

Using a `TimeVarying` background flow (I used `u(x) = (x, log(1 + t/2500))`) the advection-diffsuion of a Gaussian initial condition is

https://user-images.githubusercontent.com/75812103/172972578-806d9256-4b28-4b77-a934-2c107dbe6724.mp4 