### PR TITLE
Add 3D advection-diffusion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ license = "MIT"
 authors = ["Navid C. Constantinou <navidcy@gmail.com>", "Gregory L. Wagner <wagner.greg@gmail.com>"]
 documentation = "https://fourierflows.github.io/PassiveTracerFlowsDocumentation/dev/"
 repository = "https://github.com/FourierFlows/PassiveTracerFlows.jl"
-version = "0.7.0"
+version = "0.8.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ See `examples/` for example scripts.
 
 ## Modules
 
-* `TracerAdvectionDiffusion`: advection-diffusion of a passive tracer in 1D or 2D domains.
+* `TracerAdvectionDiffusion`: advection-diffusion of a passive tracer in 1D, 2D, or 3D domains.
 
 
 ## Cite
 
 The code is citable via [zenodo](https://zenodo.org). Please cite as:
 
-> Navid C. Constantinou, Josef Bisits, and Gregory L. Wagner (2022). FourierFlows/PassiveTracerFlows.jl: PassiveTracerFlows v0.7.0 (Version v0.7.0). Zenodo. [https://doi.org/10.5281/zenodo.2535983](https://doi.org/10.5281/zenodo.2535983)
+> Navid C. Constantinou, Josef Bisits, and Gregory L. Wagner (2022). FourierFlows/PassiveTracerFlows.jl: PassiveTracerFlows v0.8.0 (Version v0.8.0). Zenodo. [https://doi.org/10.5281/zenodo.2535983](https://doi.org/10.5281/zenodo.2535983)
 
 [FourierFlows.jl]: https://github.com/FourierFlows/FourierFlows.jl

--- a/docs/src/modules/traceradvectiondiffusion.md
+++ b/docs/src/modules/traceradvectiondiffusion.md
@@ -3,23 +3,32 @@
 ### Basic Equations
 
 This module solves the advection-diffusion equation for a passive tracer concentration in
-1D or 2D domains. 
+1D, 2D, or 3D domains. 
 
 For 1D problems the tracer concentration ``c(x, t)`` evolves under:
 
 ```math
-\partial_t c + u \partial_x c = \underbrace{\kappa \partial_x^2 c}_{\textrm{diffusivity}} + \underbrace{\kappa_h (-1)^{n_{h}} \partial_x^{2n_{h}}c}_{\textrm{hyper-diffusivity}}\ ,
+\partial_t c + u \partial_x c = \underbrace{\kappa \partial_x^2 c}_{\textrm{diffusivity}} + \underbrace{\kappa_h (-1)^{n_{h}} \partial_x^{2n_{h}}c}_{\textrm{hyper-diffusivity}} \ ,
 ```
 
-where ``u(x, t)`` is the advecting flow and ``\kappa`` the diffusivity. The advecting flow could be either compressible or incompressible. 
+where ``u(x, t)`` is the advecting flow and ``\kappa`` the diffusivity. The advecting flow can be either compressible or incompressible. 
 
 For 2D problems the tracer concentration ``c(x, y, t)`` evolves under:
 
 ```math
-\partial_t c + \bm{u} \bm{\cdot} \bm{\nabla} c = \underbrace{\eta \partial_x^2 c + \kappa \partial_y^2 c}_{\textrm{diffusivity}} + \underbrace{\kappa_h (-1)^{n_{h}} \nabla^{2n_{h}}c}_{\textrm{hyper-diffusivity}}\ ,
+\partial_t c + \bm{u} \bm{\cdot} \bm{\nabla} c = \underbrace{\eta \partial_x^2 c + \kappa \partial_y^2 c}_{\textrm{diffusivity}} + \underbrace{\kappa_h (-1)^{n_{h}} \nabla^{2n_{h}}c}_{\textrm{hyper-diffusivity}} \ ,
 ```
 
-where ``\bm{u} = (u, v)`` is the two-dimensional advecting flow, ``\eta`` the ``x``-diffusivity and ``\kappa`` is the ``y``-diffusivity. If ``\eta`` is not defined then the code uses isotropic diffusivity, i.e., ``\eta \partial_x^2 c + \kappa \partial_y^2 c \mapsto \kappa \nabla^2``. The advecting flow could be either compressible or incompressible. 
+where ``\bm{u} = (u, v)`` is the two-dimensional advecting flow, ``\kappa`` the ``x``-diffusivity and ``\eta`` is the ``y``-diffusivity. If ``\eta`` is not defined then the code uses isotropic diffusivity, i.e., ``\eta \partial_x^2 c + \kappa \partial_y^2 c \mapsto \kappa \nabla^2``. The advecting flow can be either compressible or incompressible. 
+
+
+For 3D problems the tracer concentration ``c(x, y, z, t)`` evolves under:
+
+```math
+\partial_t c + \bm{u} \bm{\cdot} \bm{\nabla} c = \underbrace{\kappa \partial_x^2 c + \eta \partial_y^2 c + \ell \partial_z^2}_{\textrm{diffusivity}} + \underbrace{\kappa_h (-1)^{n_{h}} \nabla^{2n_{h}}c}_{\textrm{hyper-diffusivity}} \ ,
+```
+
+where ``\bm{u} = (u, v, w)`` is the three-dimensional advecting flow, ``\kappa`` the ``x``-diffusivity, ``\eta`` is the ``y``-diffusivity, and ``\ell`` the ``z``-diffusivity. If ``\eta`` or ``\ell`` are not defined then the code uses isotropic diffusivity, i.e., ``\eta \partial_x^2 c + \kappa \partial_y^2 + \ell \partial_z^2 c \mapsto \kappa \nabla^2``. The advecting flow can be either compressible or incompressible. 
 
 
 ### Implementation

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -27,6 +27,8 @@ import GeophysicalFlows.MultiLayerQG
 "Abstract super type for an advecting flow."
 abstract type AbstractAdvectingFlow end
 
+noflow(args...) = 0.0 # used as defaults for u, v, w functions in AdvectingFlow constructors
+
 """
     struct OneDAdvectingFlow <: AbstractAdvectingFlow
 
@@ -36,13 +38,11 @@ Included are
 $(TYPEDFIELDS)
 """
 struct OneDAdvectingFlow <: AbstractAdvectingFlow
-    "function for the x-component of the advecting flow"
-             u :: Function
-    "boolean declaring whether or not the flow is steady (i.e., not time dependent)"
-    steadyflow :: Bool
+  "function for the x-component of the advecting flow"
+            u :: Function
+  "boolean declaring whether or not the flow is steady (i.e., not time dependent)"
+  steadyflow :: Bool
 end
-
-noflow(args...) = 0.0 # used as defaults for u, v functions in AdvectingFlow constructors
 
 """
     OneDAdvectingFlow(; u=noflow, steadyflow=true)
@@ -61,19 +61,19 @@ Included are
 $(TYPEDFIELDS)
 """
 struct TwoDAdvectingFlow <: AbstractAdvectingFlow
-    "function for the x-component of the advecting flow"
-             u :: Function
-    "function for the y-component of the advecting flow"
-             v :: Function
-    "boolean declaring whether or not the flow is steady (i.e., not time dependent)"
-    steadyflow :: Bool
+  "function for the x-component of the advecting flow"
+            u :: Function
+  "function for the y-component of the advecting flow"
+            v :: Function
+  "boolean declaring whether or not the flow is steady (i.e., not time dependent)"
+  steadyflow :: Bool
 end
 
 """
     TwoDAdvectingFlow(; u=noflow, v=noflow, steadyflow=true)
 
-Constructor for the `TwoDAdvectingFlow`. The default function for the advecting flow components is `noflow`
-hence `steadyflow=true`.    
+Return a `TwoDAdvectingFlow`. By default, there is no advecting flow `u=noflow` and `v=noflow` hence 
+`steadyflow=true`.     
 """
 TwoDAdvectingFlow(; u=noflow, v=noflow, steadyflow=true) = TwoDAdvectingFlow(u, v, steadyflow)
 
@@ -86,21 +86,21 @@ Included are
 $(TYPEDFIELDS)
 """
 struct ThreeDAdvectingFlow <: AbstractAdvectingFlow
-    "function for the x-component of the advecting flow"
-             u :: Function
-    "function for the y-component of the advecting flow"
-             v :: Function
-    "function for the z-component of the advecting flow"
-             w :: Function
-    "boolean declaring whether or not the flow is steady (i.e., not time dependent)"
-    steadyflow :: Bool
+  "function for the x-component of the advecting flow"
+            u :: Function
+  "function for the y-component of the advecting flow"
+            v :: Function
+  "function for the z-component of the advecting flow"
+            w :: Function
+  "boolean declaring whether or not the flow is steady (i.e., not time dependent)"
+  steadyflow :: Bool
 end
 
 """
     ThreeDAdvectingFlow(; u=noflow, v=noflow, w=noflow, steadyflow=true)
 
-Constructor for the `ThreeDAdvectingFlow`. The default function for the advecting flow components is `noflow`
-hence `steadyflow=true`.    
+Return a `ThreeDAdvectingFlow`. By default, there is no advecting flow `u=noflow`, `v=noflow` and `w=noflow` hence 
+`steadyflow=true`.    
 """
 ThreeDAdvectingFlow(; u=noflow, v=noflow, w=noflow, steadyflow=true) = ThreeDAdvectingFlow(u, v, w, steadyflow)
 
@@ -165,31 +165,31 @@ function Problem(dev, advecting_flow::TwoDAdvectingFlow;
 end
 
 function Problem(dev, advecting_flow::ThreeDAdvectingFlow;
-    nx = 128,
-    Lx = 2π,
-    ny = nx,
-    Ly = Lx,
-    nz = nx,
-    Lz = Lx,
-     κ = 0.1,
-     η = κ,
-     ι = κ,
-    dt = 0.01,
-stepper = "RK4",
-     T = Float64
-)
+                    nx = 128,
+                    Lx = 2π,
+                    ny = nx,
+                    Ly = Lx,
+                    nz = nx,
+                    Lz = Lx,
+                    κ = 0.1,
+                    η = κ,
+                    ι = κ,
+                    dt = 0.01,
+                stepper = "RK4",
+                    T = Float64
+                )
 
-grid = ThreeDGrid(dev, nx, Lx, ny, Ly, nz, Lz; T)
+  grid = ThreeDGrid(dev, nx, Lx, ny, Ly, nz, Lz; T)
 
-params = advecting_flow.steadyflow==true ?
-ConstDiffSteadyFlowParams(η, κ, ι, advecting_flow.u, advecting_flow.v, advecting_flow.w, grid::ThreeDGrid) :
-ConstDiffTimeVaryingFlowParams(η, κ, ι, advecting_flow.u, advecting_flow.v, advecting_flow.w)
+  params = advecting_flow.steadyflow==true ?
+  ConstDiffSteadyFlowParams(η, κ, ι, advecting_flow.u, advecting_flow.v, advecting_flow.w, grid::ThreeDGrid) :
+  ConstDiffTimeVaryingFlowParams(η, κ, ι, advecting_flow.u, advecting_flow.v, advecting_flow.w)
 
-vars = Vars(dev, grid; T)
+  vars = Vars(dev, grid; T)
 
-equation = Equation(dev, params, grid)
+  equation = Equation(dev, params, grid)
 
-return FourierFlows.Problem(equation, stepper, dt, grid, vars, params, dev)
+  return FourierFlows.Problem(equation, stepper, dt, grid, vars, params, dev)
 end
 
 """
@@ -203,7 +203,7 @@ function Problem(dev, MQGprob::FourierFlows.Problem;
                      η = κ,
                stepper = "FilteredRK4",
    tracer_release_time = 0
-  )
+                )
   
   grid = MQGprob.grid
   
@@ -240,14 +240,14 @@ dimension. Included are:
 $(TYPEDFIELDS)
 """
 struct ConstDiffTimeVaryingFlowParams1D{T} <: AbstractTimeVaryingFlowParams
-    "isotropic horizontal diffusivity coefficient"
-       κ :: T
-    "isotropic hyperdiffusivity coefficient"
-      κh :: T
-    "isotropic hyperdiffusivity order"  
-     nκh :: Int
-    "function returning the x-component of advecting flow"
-       u :: Function
+  "isotropic horizontal diffusivity coefficient"
+      κ :: T
+  "isotropic hyperdiffusivity coefficient"
+    κh :: T
+  "isotropic hyperdiffusivity order"  
+    nκh :: Int
+  "function returning the x-component of advecting flow"
+      u :: Function
 end
 
 """
@@ -259,18 +259,18 @@ dimensions. Included are:
 $(TYPEDFIELDS)
 """
 struct ConstDiffTimeVaryingFlowParams2D{T} <: AbstractTimeVaryingFlowParams
-    "isotropic horizontal diffusivity coefficient"
-       η :: T
-    "isotropic vertical diffusivity coefficient"
-       κ :: T
-    "isotropic hyperdiffusivity coefficient"
-      κh :: T
-    "isotropic hyperdiffusivity order"  
-     nκh :: Int
-    "function returning the x-component of advecting flow"
-       u :: Function
-    "function returning the y-component of advecting flow"
-       v :: Function
+  "isotropic horizontal diffusivity coefficient"
+      η :: T
+  "isotropic vertical diffusivity coefficient"
+      κ :: T
+  "isotropic hyperdiffusivity coefficient"
+    κh :: T
+  "isotropic hyperdiffusivity order"  
+    nκh :: Int
+  "function returning the x-component of advecting flow"
+      u :: Function
+  "function returning the y-component of advecting flow"
+      v :: Function
 end
 
 """
@@ -282,29 +282,30 @@ dimensions. Included are:
 $(TYPEDFIELDS)
 """
 struct ConstDiffTimeVaryingFlowParams3D{T} <: AbstractTimeVaryingFlowParams
-    "isotropic horizontal (x) diffusivity coefficient"
-       η :: T
-    "isotropic horizontal (y) diffusivity coefficient"
-       κ :: T
-    "isotropic vertical diffusivity coefficient"
-       ι :: T
-    "isotropic hyperdiffusivity coefficient"
-      κh :: T
-    "isotropic hyperdiffusivity order"  
-     nκh :: Int
-    "function returning the x-component of advecting flow"
-       u :: Function
-    "function returning the y-component of advecting flow"
-       v :: Function
-    "function returning the z-component of advecting flow"
-       w :: Function
+  "isotropic horizontal (x) diffusivity coefficient"
+      η :: T
+  "isotropic horizontal (y) diffusivity coefficient"
+      κ :: T
+  "isotropic vertical diffusivity coefficient"
+      ι :: T
+  "isotropic hyperdiffusivity coefficient"
+    κh :: T
+  "isotropic hyperdiffusivity order"  
+    nκh :: Int
+  "function returning the x-component of advecting flow"
+      u :: Function
+  "function returning the y-component of advecting flow"
+      v :: Function
+  "function returning the z-component of advecting flow"
+      w :: Function
 end
 
 """
     ConstDiffTimeVaryingFlowParams(κ, u)
     ConstDiffTimeVaryingFlowParams(η, κ, u, v)
+    ConstDiffTimeVaryingFlowParams(η, κ, ι, u, v, w)
 
-The constructor for the `params` struct for constant diffusivity problem and time-varying flow.
+Return the parameters `params` for a constant diffusivity problem with a time varying flow in 1D, 2D or 3D. 
 """
 ConstDiffTimeVaryingFlowParams(κ, u) = ConstDiffTimeVaryingFlowParams1D(κ, 0κ, 0, u)
 ConstDiffTimeVaryingFlowParams(η, κ, u, v) = ConstDiffTimeVaryingFlowParams2D(η, κ, 0η, 0, u, v)
@@ -325,7 +326,7 @@ struct ConstDiffSteadyFlowParams1D{T, A} <: AbstractSteadyFlowParams
     κh :: T
   "isotropic hyperdiffusivity order"  
    nκh :: Int
-   "x-component of advecting flow"
+  "x-component of advecting flow"
      u :: A
 end
 
@@ -387,19 +388,19 @@ end
     ConstDiffSteadyFlowParams(η, κ, ι, κh, nκh, u::Function, v::Function, w::Function, grid::ThreeDGrid)
     ConstDiffSteadyFlowParams(η, κ, ι, u, v, w, grid::ThreeDGrid)
 
-Return the parameters `params` for a constant diffusivity problem and steady flow.
+Return the parameters `params` for a constant diffusivity problem with a steady flow in 1D, 2D or 3D. 
 """
 function ConstDiffSteadyFlowParams(κ, κh, nκh, u::Function, grid::OneDGrid)
-   x = gridpoints(grid)
-   ugrid = u.(x)
-   
-   return ConstDiffSteadyFlowParams1D(κ, κh, nκh, ugrid)
- end
+  x = gridpoints(grid)
+  ugrid = u.(x)
+  
+  return ConstDiffSteadyFlowParams1D(κ, κh, nκh, ugrid)
+end
  
  ConstDiffSteadyFlowParams(κ, u, grid::OneDGrid) = ConstDiffSteadyFlowParams(κ, 0κ, 0, u, grid)
 
 function ConstDiffSteadyFlowParams(η, κ, κh, nκh, u::Function, v::Function, grid::TwoDGrid)
-   x, y = gridpoints(grid)
+  x, y = gridpoints(grid)
   ugrid = u.(x, y)
   vgrid = v.(x, y)
   
@@ -409,12 +410,12 @@ end
 ConstDiffSteadyFlowParams(η, κ, u, v, grid::TwoDGrid) = ConstDiffSteadyFlowParams(η, κ, 0η, 0, u, v, grid)
 
 function ConstDiffSteadyFlowParams(η, κ, ι, κh, nκh, u::Function, v::Function, w::Function, grid::ThreeDGrid)
-    x, y, z = gridpoints(grid)
-   ugrid = u.(x, y, z)
-   vgrid = v.(x, y, z)
-   wgrid = w.(x, y, z)
+  x, y, z = gridpoints(grid)
+  ugrid = u.(x, y, z)
+  vgrid = v.(x, y, z)
+  wgrid = w.(x, y, z)
    
-   return ConstDiffSteadyFlowParams3D(η, κ, ι, κh, nκh, ugrid, vgrid, wgrid)
+  return ConstDiffSteadyFlowParams3D(η, κ, ι, κh, nκh, ugrid, vgrid, wgrid)
  end
  
  ConstDiffSteadyFlowParams(η, κ, ι, u, v, w, grid::ThreeDGrid) = ConstDiffSteadyFlowParams(η, κ, ι, 0η, 0, u, v, w, grid)
@@ -467,46 +468,46 @@ end
 
 Return the equation for constant diffusivity problem with `params` and `grid` on device `dev`.
 """
-function Equation(dev, params::ConstDiffTimeVaryingFlowParams1D, grid)
-    L = zeros(dev, eltype(grid), (grid.nkr))
-    @. L = - params.κ * grid.kr^2 - params.κh * (grid.kr^2)^params.nκh
-    
-    return FourierFlows.Equation(L, calcN!, grid)
+function Equation(dev, params::ConstDiffTimeVaryingFlowParams1D, grid::OneDGrid)
+  L = zeros(dev, eltype(grid), (grid.nkr))
+  @. L = - params.κ * grid.kr^2 - params.κh * (grid.kr^2)^params.nκh
+  
+  return FourierFlows.Equation(L, calcN!, grid)
 end
 
-function Equation(dev, params::ConstDiffTimeVaryingFlowParams2D, grid)
+function Equation(dev, params::ConstDiffTimeVaryingFlowParams2D, grid::TwoDGrid)
   L = zeros(dev, eltype(grid), (grid.nkr, grid.nl))
   @. L = - params.η * grid.kr^2 - params.κ * grid.l^2 - params.κh * grid.Krsq^params.nκh
   
   return FourierFlows.Equation(L, calcN!, grid)
 end
 
-function Equation(dev, params::ConstDiffTimeVaryingFlowParams3D, grid)
-    L = zeros(dev, eltype(grid), (grid.nkr, grid.nl, grid.nm))
-    @. L = - params.η * grid.kr^2 - params.κ * grid.l^2 - params.ι * grid.m^2 - params.κh * grid.Krsq^params.nκh
-    
-    return FourierFlows.Equation(L, calcN!, grid)
+function Equation(dev, params::ConstDiffTimeVaryingFlowParams3D, grid::ThreeDGrid)
+  L = zeros(dev, eltype(grid), (grid.nkr, grid.nl, grid.nm))
+  @. L = - params.η * grid.kr^2 - params.κ * grid.l^2 - params.ι * grid.m^2 - params.κh * grid.Krsq^params.nκh
+  
+  return FourierFlows.Equation(L, calcN!, grid)
 end
 
-function Equation(dev, params::ConstDiffSteadyFlowParams1D, grid)
-    L = zeros(dev, eltype(grid), (grid.nkr))
-    @. L = - params.κ * grid.kr^2 - params.κh * (grid.kr^2)^params.nκh
-    
-    return FourierFlows.Equation(L, calcN_steadyflow!, grid)
+function Equation(dev, params::ConstDiffSteadyFlowParams1D, grid::OneDGrid)
+  L = zeros(dev, eltype(grid), (grid.nkr))
+  @. L = - params.κ * grid.kr^2 - params.κh * (grid.kr^2)^params.nκh
+  
+  return FourierFlows.Equation(L, calcN_steadyflow!, grid)
 end
 
-function Equation(dev, params::ConstDiffSteadyFlowParams2D, grid)
+function Equation(dev, params::ConstDiffSteadyFlowParams2D, grid::TwoDGrid)
   L = zeros(dev, eltype(grid), (grid.nkr, grid.nl))
   @. L = - params.η * grid.kr^2 - params.κ * grid.l^2 - params.κh * grid.Krsq^params.nκh
   
   return FourierFlows.Equation(L, calcN_steadyflow!, grid)
 end
 
-function Equation(dev, params::ConstDiffSteadyFlowParams3D, grid)
-    L = zeros(dev, eltype(grid), (grid.nkr, grid.nl, grid.nm))
-    @. L = - params.η * grid.kr^2 - params.κ * grid.l^2 - params.ι * grid.m^2 - params.κh * grid.Krsq^params.nκh
-    
-    return FourierFlows.Equation(L, calcN_steadyflow!, grid)
+function Equation(dev, params::ConstDiffSteadyFlowParams3D, grid::ThreeDGrid)
+  L = zeros(dev, eltype(grid), (grid.nkr, grid.nl, grid.nm))
+  @. L = - params.η * grid.kr^2 - params.κ * grid.l^2 - params.ι * grid.m^2 - params.κh * grid.Krsq^params.nκh
+  
+  return FourierFlows.Equation(L, calcN_steadyflow!, grid)
 end
 
 function Equation(dev, params::ConstDiffTurbulentFlowParams, grid)
@@ -531,14 +532,14 @@ The variables for a 1D `TracerAdvectionDiffussion` problem.
 $(FIELDS)
 """
 struct Vars1D{Aphys, Atrans} <: AbstractVars
-    "tracer concentration"
-       c :: Aphys
-    "tracer concentration ``x``-derivative, ``∂c/∂x``"
-      cx :: Aphys
-    "Fourier transform of tracer concentration"
-      ch :: Atrans
-    "Fourier transform of tracer concentration ``x``-derivative, ``∂c/∂x``"
-     cxh :: Atrans
+  "tracer concentration"
+      c :: Aphys
+  "tracer concentration ``x``-derivative, ``∂c/∂x``"
+    cx :: Aphys
+  "Fourier transform of tracer concentration"
+    ch :: Atrans
+  "Fourier transform of tracer concentration ``x``-derivative, ``∂c/∂x``"
+    cxh :: Atrans
 end
 
 """
@@ -549,18 +550,18 @@ The variables for a 2D `TracerAdvectionDiffussion` problem.
 $(FIELDS)
 """
 struct Vars2D{Aphys, Atrans} <: AbstractVars
-    "tracer concentration"
-       c :: Aphys
-    "tracer concentration ``x``-derivative, ``∂c/∂x``"
-      cx :: Aphys
-    "tracer concentration ``y``-derivative, ``∂c/∂y``"
-      cy :: Aphys
-    "Fourier transform of tracer concentration"
-      ch :: Atrans
-    "Fourier transform of tracer concentration ``x``-derivative, ``∂c/∂x``"
-     cxh :: Atrans
-    "Fourier transform of tracer concentration ``y``-derivative, ``∂c/∂y``"
-     cyh :: Atrans
+  "tracer concentration"
+      c :: Aphys
+  "tracer concentration ``x``-derivative, ``∂c/∂x``"
+    cx :: Aphys
+  "tracer concentration ``y``-derivative, ``∂c/∂y``"
+    cy :: Aphys
+  "Fourier transform of tracer concentration"
+    ch :: Atrans
+  "Fourier transform of tracer concentration ``x``-derivative, ``∂c/∂x``"
+    cxh :: Atrans
+  "Fourier transform of tracer concentration ``y``-derivative, ``∂c/∂y``"
+    cyh :: Atrans
 end
 
 """
@@ -571,22 +572,22 @@ The variables for a 3D `TracerAdvectionDiffussion` problem.
 $(FIELDS)
 """
 struct Vars3D{Aphys, Atrans} <: AbstractVars
-    "tracer concentration"
-       c :: Aphys
-    "tracer concentration ``x``-derivative, ``∂c/∂x``"
-      cx :: Aphys
-    "tracer concentration ``y``-derivative, ``∂c/∂y``"
-      cy :: Aphys
-    "tracer concentration ``z``-derivative, ``∂c/∂z``"
-      cz :: Aphys
-    "Fourier transform of tracer concentration"
-      ch :: Atrans
-    "Fourier transform of tracer concentration ``x``-derivative, ``∂c/∂x``"
-     cxh :: Atrans
-    "Fourier transform of tracer concentration ``y``-derivative, ``∂c/∂y``"
-     cyh :: Atrans
-     "Fourier transform of tracer concentration ``z``-derivative, ``∂c/∂z``"
-     czh :: Atrans
+  "tracer concentration"
+      c :: Aphys
+  "tracer concentration ``x``-derivative, ``∂c/∂x``"
+    cx :: Aphys
+  "tracer concentration ``y``-derivative, ``∂c/∂y``"
+    cy :: Aphys
+  "tracer concentration ``z``-derivative, ``∂c/∂z``"
+    cz :: Aphys
+  "Fourier transform of tracer concentration"
+    ch :: Atrans
+  "Fourier transform of tracer concentration ``x``-derivative, ``∂c/∂x``"
+    cxh :: Atrans
+  "Fourier transform of tracer concentration ``y``-derivative, ``∂c/∂y``"
+    cyh :: Atrans
+    "Fourier transform of tracer concentration ``z``-derivative, ``∂c/∂z``"
+    czh :: Atrans
 end
 
 """
@@ -640,15 +641,15 @@ end
 Calculate the advective terms for a tracer equation with constant diffusivity and time-varying flow.
 """
 function calcN!(N, sol, t, clock, vars, params::AbstractTimeVaryingFlowParams, grid::OneDGrid)
-    @. vars.cxh = im * grid.kr * sol
+  @. vars.cxh = im * grid.kr * sol
+
+  ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
+
+  x = grid.x
+  @. vars.cx = -params.u(x, clock.t) * vars.cx # copies over vars.cx so vars.cx = N in physical space
+  mul!(N, grid.rfftplan, vars.cx)
   
-    ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
-  
-    x = grid.x
-    @. vars.cx = -params.u(x, clock.t) * vars.cx # copies over vars.cx so vars.cx = N in physical space
-    mul!(N, grid.rfftplan, vars.cx)
-    
-    return nothing
+  return nothing
 end
 
 function calcN!(N, sol, t, clock, vars, params::AbstractTimeVaryingFlowParams, grid::TwoDGrid)
@@ -666,19 +667,19 @@ function calcN!(N, sol, t, clock, vars, params::AbstractTimeVaryingFlowParams, g
 end
 
 function calcN!(N, sol, t, clock, vars, params::AbstractTimeVaryingFlowParams, grid::ThreeDGrid)
-    @. vars.cxh = im * grid.kr * sol
-    @. vars.cyh = im * grid.l  * sol
-    @. vars.czh = im * grid.m  * sol
+  @. vars.cxh = im * grid.kr * sol
+  @. vars.cyh = im * grid.l  * sol
+  @. vars.czh = im * grid.m  * sol
+
+  ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
+  ldiv!(vars.cy, grid.rfftplan, vars.cyh) # destroys vars.cyh when using fftw
+  ldiv!(vars.cz, grid.rfftplan, vars.czh) # destroys vars.cyh when using fftw
+
+  x, y, z = gridpoints(grid)
+  @. vars.cx = -params.u(x, y, z, clock.t) * vars.cx - params.v(x, y, z, clock.t) * vars.cy - params.w(x, y, z, clock.t) * vars.cz # copies over vars.cx so vars.cx = N in physical space
+  mul!(N, grid.rfftplan, vars.cx)
   
-    ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
-    ldiv!(vars.cy, grid.rfftplan, vars.cyh) # destroys vars.cyh when using fftw
-    ldiv!(vars.cz, grid.rfftplan, vars.czh) # destroys vars.cyh when using fftw
-  
-    x, y, z = gridpoints(grid)
-    @. vars.cx = -params.u(x, y, z, clock.t) * vars.cx - params.v(x, y, z, clock.t) * vars.cy - params.w(x, y, z, clock.t) * vars.cz # copies over vars.cx so vars.cx = N in physical space
-    mul!(N, grid.rfftplan, vars.cx)
-    
-    return nothing
+  return nothing
   end
 
 
@@ -688,14 +689,14 @@ function calcN!(N, sol, t, clock, vars, params::AbstractTimeVaryingFlowParams, g
 Calculate the advective terms for a tracer equation with constant diffusivity and time-constant flow.
 """
 function calcN_steadyflow!(N, sol, t, clock, vars, params::AbstractSteadyFlowParams, grid::OneDGrid)
-    @. vars.cxh = im * grid.kr * sol
+  @. vars.cxh = im * grid.kr * sol
+
+  ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
+
+  @. vars.cx = -params.u * vars.cx # copies over vars.cx so vars.cx = N in physical space
+  mul!(N, grid.rfftplan, vars.cx)
   
-    ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
-  
-    @. vars.cx = -params.u * vars.cx # copies over vars.cx so vars.cx = N in physical space
-    mul!(N, grid.rfftplan, vars.cx)
-    
-    return nothing
+  return nothing
 end
 
 function calcN_steadyflow!(N, sol, t, clock, vars, params::AbstractSteadyFlowParams, grid::TwoDGrid)
@@ -712,18 +713,18 @@ function calcN_steadyflow!(N, sol, t, clock, vars, params::AbstractSteadyFlowPar
 end
 
 function calcN_steadyflow!(N, sol, t, clock, vars, params::AbstractSteadyFlowParams, grid::ThreeDGrid)
-    @. vars.cxh = im * grid.kr * sol
-    @. vars.cyh = im * grid.l  * sol
-    @. vars.czh = im * grid.m  * sol
-  
-    ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
-    ldiv!(vars.cy, grid.rfftplan, vars.cyh) # destroys vars.cyh when using fftw
-    ldiv!(vars.cz, grid.rfftplan, vars.czh) # destroys vars.cyh when using fftw
+  @. vars.cxh = im * grid.kr * sol
+  @. vars.cyh = im * grid.l  * sol
+  @. vars.czh = im * grid.m  * sol
 
-    @. vars.cx = -params.u * vars.cx - params.v * vars.cy - params.w * vars.cz # copies over vars.cx so vars.cx = N in physical space
-    mul!(N, grid.rfftplan, vars.cx)
-    
-    return nothing
+  ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
+  ldiv!(vars.cy, grid.rfftplan, vars.cyh) # destroys vars.cyh when using fftw
+  ldiv!(vars.cz, grid.rfftplan, vars.czh) # destroys vars.cyh when using fftw
+
+  @. vars.cx = -params.u * vars.cx - params.v * vars.cy - params.w * vars.cz # copies over vars.cx so vars.cx = N in physical space
+  mul!(N, grid.rfftplan, vars.cx)
+  
+  return nothing
 end
 
 """

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -32,13 +32,13 @@ noflow(args...) = 0.0 # used as defaults for u, v, w functions in AdvectingFlow 
 """
     struct OneDAdvectingFlow <: AbstractAdvectingFlow
 
-A struct containing the advecting flow for a one dimensional `TracerAdvectionDiffusion.Problem`.
-Included are
+A container for the advecting flow of a one dimensional `TracerAdvectionDiffusion.Problem`.
+Includes:
 
 $(TYPEDFIELDS)
 """
 struct OneDAdvectingFlow <: AbstractAdvectingFlow
-  "function for the x-component of the advecting flow"
+  "function for the ``x``-component of the advecting flow"
             u :: Function
   "boolean declaring whether or not the flow is steady (i.e., not time dependent)"
   steadyflow :: Bool
@@ -55,15 +55,15 @@ OneDAdvectingFlow(; u=noflow, steadyflow=true) = OneDAdvectingFlow(u, steadyflow
 """
     struct TwoDAdvectingFlow <: AbstractAdvectingFlow
 
-A struct containing the advecting flow for a two dimensional `TracerAdvectionDiffusion.Problem`.
-Included are
+A container for the advecting flow of a two dimensional `TracerAdvectionDiffusion.Problem`.
+Includes:
 
 $(TYPEDFIELDS)
 """
 struct TwoDAdvectingFlow <: AbstractAdvectingFlow
-  "function for the x-component of the advecting flow"
+  "function for the ``x``-component of the advecting flow"
             u :: Function
-  "function for the y-component of the advecting flow"
+  "function for the ``y``-component of the advecting flow"
             v :: Function
   "boolean declaring whether or not the flow is steady (i.e., not time dependent)"
   steadyflow :: Bool
@@ -80,17 +80,17 @@ TwoDAdvectingFlow(; u=noflow, v=noflow, steadyflow=true) = TwoDAdvectingFlow(u, 
 """
     struct ThreeDAdvectingFlow <: AbstractAdvectingFlow
 
-A struct containing the advecting flow for a three dimensional `TracerAdvectionDiffusion.Problem`.
-Included are
+A container for the advecting flow of a three dimensional `TracerAdvectionDiffusion.Problem`.
+Includes:
 
 $(TYPEDFIELDS)
 """
 struct ThreeDAdvectingFlow <: AbstractAdvectingFlow
-  "function for the x-component of the advecting flow"
+  "function for the ``x``-component of the advecting flow"
             u :: Function
-  "function for the y-component of the advecting flow"
+  "function for the ``y``-component of the advecting flow"
             v :: Function
-  "function for the z-component of the advecting flow"
+  "function for the ``z``-component of the advecting flow"
             w :: Function
   "boolean declaring whether or not the flow is steady (i.e., not time dependent)"
   steadyflow :: Bool
@@ -99,8 +99,8 @@ end
 """
     ThreeDAdvectingFlow(; u=noflow, v=noflow, w=noflow, steadyflow=true)
 
-Return a `ThreeDAdvectingFlow`. By default, there is no advecting flow `u=noflow`, `v=noflow` and `w=noflow` hence 
-`steadyflow=true`.    
+Return a `ThreeDAdvectingFlow`. By default, there is no advecting flow `u=noflow`, `v=noflow`, and `w=noflow`
+hence `steadyflow=true`.    
 """
 ThreeDAdvectingFlow(; u=noflow, v=noflow, w=noflow, steadyflow=true) = ThreeDAdvectingFlow(u, v, w, steadyflow)
 
@@ -112,10 +112,10 @@ ThreeDAdvectingFlow(; u=noflow, v=noflow, w=noflow, steadyflow=true) = ThreeDAdv
     Problem(dev, advecting_flow; parameters...)
 
 Construct a constant diffusivity problem with steady or time-varying `advecting_flow` on device `dev`.
-The dimensionality of the problem is inferred from the `advecting_flow`:
+The dimensionality of the problem is inferred from the type of `advecting_flow` provided:
 * `advecting_flow::OneDAdvectingFlow` for 1D advection-diffusion problem,
 * `advecting_flow::TwoDAdvectingFlow` for 2D advection-diffusion problem,
-* `advecting_flow::ThreeDAdvectingFlow` for 3D advection-diffusion problem
+* `advecting_flow::ThreeDAdvectingFlow` for 3D advection-diffusion problem.
 """
 function Problem(dev, advecting_flow::OneDAdvectingFlow;
                      nx = 128,
@@ -182,8 +182,8 @@ function Problem(dev, advecting_flow::ThreeDAdvectingFlow;
   grid = ThreeDGrid(dev, nx, Lx, ny, Ly, nz, Lz; T)
 
   params = advecting_flow.steadyflow==true ?
-  ConstDiffSteadyFlowParams(η, κ, ι, advecting_flow.u, advecting_flow.v, advecting_flow.w, grid::ThreeDGrid) :
-  ConstDiffTimeVaryingFlowParams(η, κ, ι, advecting_flow.u, advecting_flow.v, advecting_flow.w)
+  ConstDiffSteadyFlowParams(κ, η, ι, advecting_flow.u, advecting_flow.v, advecting_flow.w, grid::ThreeDGrid) :
+  ConstDiffTimeVaryingFlowParams(κ, η, ι, advecting_flow.u, advecting_flow.v, advecting_flow.w)
 
   vars = Vars(dev, grid; T)
 
@@ -234,159 +234,169 @@ abstract type AbstractTurbulentFlowParams <: AbstractParams end
 """
     struct ConstDiffTimeVaryingFlowParams1D{T} <: AbstractTimeVaryingFlowParams
 
-A struct containing the parameters for a constant diffusivity problem with time-varying flow in one
-dimension. Included are:
+The parameters of a constant diffusivity problem with time-varying flow in one
+dimension.
 
 $(TYPEDFIELDS)
 """
 struct ConstDiffTimeVaryingFlowParams1D{T} <: AbstractTimeVaryingFlowParams
-  "isotropic horizontal diffusivity coefficient"
+  "diffusivity coefficient"
       κ :: T
-  "isotropic hyperdiffusivity coefficient"
+  "hyperdiffusivity coefficient"
     κh :: T
-  "isotropic hyperdiffusivity order"  
+  "hyperdiffusivity order"  
     nκh :: Int
-  "function returning the x-component of advecting flow"
+  "function returning the ``x``-component of advecting flow"
       u :: Function
 end
 
 """
     struct ConstDiffTimeVaryingFlowParams2D{T} <: AbstractTimeVaryingFlowParams
 
-A struct containing the parameters for a constant diffusivity problem with time-varying flow in two
-dimensions. Included are:
+The parameters of a constant diffusivity problem with time-varying flow in two
+dimensions.
 
 $(TYPEDFIELDS)
 """
 struct ConstDiffTimeVaryingFlowParams2D{T} <: AbstractTimeVaryingFlowParams
-  "isotropic horizontal diffusivity coefficient"
-      η :: T
-  "isotropic vertical diffusivity coefficient"
+  "``x``-diffusivity coefficient"
       κ :: T
+  "``y``-diffusivity coefficient"
+      η :: T
   "isotropic hyperdiffusivity coefficient"
     κh :: T
   "isotropic hyperdiffusivity order"  
     nκh :: Int
-  "function returning the x-component of advecting flow"
+  "function returning the ``x``-component of advecting flow"
       u :: Function
-  "function returning the y-component of advecting flow"
+  "function returning the ``y``-component of advecting flow"
       v :: Function
 end
 
 """
     struct ConstDiffTimeVaryingFlowParams3D{T} <: AbstractTimeVaryingFlowParams
 
-A struct containing the parameters for a constant diffusivity problem with time-varying flow in three
-dimensions. Included are:
+The parameters of a constant diffusivity problem with time-varying flow in three
+dimensions.
 
 $(TYPEDFIELDS)
 """
 struct ConstDiffTimeVaryingFlowParams3D{T} <: AbstractTimeVaryingFlowParams
-  "isotropic horizontal (x) diffusivity coefficient"
-      η :: T
-  "isotropic horizontal (y) diffusivity coefficient"
+  "``x``-diffusivity coefficient"
       κ :: T
-  "isotropic vertical diffusivity coefficient"
+  "``y``-diffusivity coefficient"
+      η :: T
+  "``z``-diffusivity coefficient"
       ι :: T
   "isotropic hyperdiffusivity coefficient"
     κh :: T
   "isotropic hyperdiffusivity order"  
     nκh :: Int
-  "function returning the x-component of advecting flow"
+  "function returning the ``x``-component of advecting flow"
       u :: Function
-  "function returning the y-component of advecting flow"
+  "function returning the ``y``-component of advecting flow"
       v :: Function
-  "function returning the z-component of advecting flow"
+  "function returning the ``z``-component of advecting flow"
       w :: Function
 end
 
 """
     ConstDiffTimeVaryingFlowParams(κ, u)
-    ConstDiffTimeVaryingFlowParams(η, κ, u, v)
-    ConstDiffTimeVaryingFlowParams(η, κ, ι, u, v, w)
 
-Return the parameters `params` for a constant diffusivity problem with a time varying flow in 1D, 2D or 3D. 
+Return the parameters `params` for a constant diffusivity problem with a 1D time-varying flow.
 """
 ConstDiffTimeVaryingFlowParams(κ, u) = ConstDiffTimeVaryingFlowParams1D(κ, 0κ, 0, u)
-ConstDiffTimeVaryingFlowParams(η, κ, u, v) = ConstDiffTimeVaryingFlowParams2D(η, κ, 0η, 0, u, v)
-ConstDiffTimeVaryingFlowParams(η, κ, ι, u, v, w) = ConstDiffTimeVaryingFlowParams3D(η, κ, ι, 0η, 0, u, v, w)
+
+"""
+    ConstDiffTimeVaryingFlowParams(κ, η, u, v)
+
+Return the parameters `params` for a constant diffusivity problem with a 2D time-varying flow.
+"""
+ConstDiffTimeVaryingFlowParams(κ, η, u, v) = ConstDiffTimeVaryingFlowParams2D(κ, η, 0κ, 0, u, v)
+
+"""
+    ConstDiffTimeVaryingFlowParams(κ, η, ι, u, v, w)
+
+Return the parameters `params` for a constant diffusivity problem with a 3D time-varying flow.
+"""
+ConstDiffTimeVaryingFlowParams(κ, η, ι, u, v, w) = ConstDiffTimeVaryingFlowParams3D(κ, η, ι, 0κ, 0, u, v, w)
 
 """
     struct ConstDiffSteadyFlowParams1D{T} <: AbstractSteadyFlowParams
 
-A struct containing the parameters for a constant diffusivity problem with steady flow in one dimensions.
-Included are:
+A container forthe parameters of aa constant diffusivity problem with steady flow in one dimensions.
+Includes:
 
 $(TYPEDFIELDS)
 """
 struct ConstDiffSteadyFlowParams1D{T, A} <: AbstractSteadyFlowParams
-  "isotropic horizontal diffusivity coefficient"
+  "``x``-diffusivity coefficient"
      κ :: T
   "isotropic hyperdiffusivity coefficient"
     κh :: T
   "isotropic hyperdiffusivity order"  
    nκh :: Int
-  "x-component of advecting flow"
+  "``x``-component of advecting flow"
      u :: A
 end
 
 """
     struct ConstDiffSteadyFlowParams2D{T} <: AbstractSteadyFlowParams
 
-A struct containing the parameters for a constant diffusivity problem with steady flow in two dimensions.
-Included are:
+A container for the parameters for a constant diffusivity problem with steady flow in two dimensions.
+Includes:
 
 $(TYPEDFIELDS)
 """
 struct ConstDiffSteadyFlowParams2D{T, A} <: AbstractSteadyFlowParams
-  "isotropic horizontal diffusivity coefficient"
-     η :: T
-  "isotropic vertical diffusivity coefficient"
+  "``x``-diffusivity coefficient"
      κ :: T
+  "``y``-diffusivity coefficient"
+     η :: T
   "isotropic hyperdiffusivity coefficient"
     κh :: T
   "isotropic hyperdiffusivity order"  
    nκh :: Int
-   "x-component of advecting flow"
+   "``x``-component of advecting flow"
      u :: A
-   "y-component of advecting flow"
+   "``y``-component of advecting flow"
      v :: A
 end
 
 """
     struct ConstDiffSteadyFlowParams3D{T} <: AbstractSteadyFlowParams
 
-A struct containing the parameters for a constant diffusivity problem with steady flow in three dimensions.
-Included are:
+A container for the parameters for a constant diffusivity problem with steady flow in three dimensions.
+Includes:
 
 $(TYPEDFIELDS)
 """
 struct ConstDiffSteadyFlowParams3D{T, A} <: AbstractSteadyFlowParams
-  "isotropic horizontal (x) diffusivity coefficient"
-     η :: T
-  "isotropic horizontal (y) diffusivity coefficient"
+  "``x``-diffusivity coefficient"
      κ :: T
-  "isotropic vertical diffusivity coefficient"
+  "``y``-diffusivity coefficient"
+     η :: T
+  "``z``-diffusivity coefficient"
      ι :: T
   "isotropic hyperdiffusivity coefficient"
     κh :: T
   "isotropic hyperdiffusivity order"  
    nκh :: Int
-   "x-component of advecting flow"
+   "``x``-component of advecting flow"
      u :: A
-   "y-component of advecting flow"
+   "``y``-component of advecting flow"
      v :: A
-   "z-component of advecting flow"
+   "``z``-component of advecting flow"
      w :: A
 end
 
 """
     ConstDiffSteadyFlowParams(κ, κh, nκh, u::Function, grid::OneDGrid)
     ConstDiffSteadyFlowParams(κ, u, grid::OneDGrid)
-    ConstDiffSteadyFlowParams(η, κ, κh, nκh, u::Function, v::Function, grid::TwoDGrid)
-    ConstDiffSteadyFlowParams(η, κ, u, v, grid::TwoDGrid)
-    ConstDiffSteadyFlowParams(η, κ, ι, κh, nκh, u::Function, v::Function, w::Function, grid::ThreeDGrid)
-    ConstDiffSteadyFlowParams(η, κ, ι, u, v, w, grid::ThreeDGrid)
+    ConstDiffSteadyFlowParams(κ, η, κh, nκh, u::Function, v::Function, grid::TwoDGrid)
+    ConstDiffSteadyFlowParams(κ, η, u, v, grid::TwoDGrid)
+    ConstDiffSteadyFlowParams(κ, η, ι, κh, nκh, u::Function, v::Function, w::Function, grid::ThreeDGrid)
+    ConstDiffSteadyFlowParams(κ, η, ι, u, v, w, grid::ThreeDGrid)
 
 Return the parameters `params` for a constant diffusivity problem with a steady flow in 1D, 2D or 3D. 
 """
@@ -397,42 +407,40 @@ function ConstDiffSteadyFlowParams(κ, κh, nκh, u::Function, grid::OneDGrid)
   return ConstDiffSteadyFlowParams1D(κ, κh, nκh, ugrid)
 end
  
- ConstDiffSteadyFlowParams(κ, u, grid::OneDGrid) = ConstDiffSteadyFlowParams(κ, 0κ, 0, u, grid)
+ ConstDiffSteadyFlowParams(κ, u, grid::OneDGrid) =
+  σConstDiffSteadyFlowParams(κ, 0κ, 0, u, grid)
 
-function ConstDiffSteadyFlowParams(η, κ, κh, nκh, u::Function, v::Function, grid::TwoDGrid)
+function ConstDiffSteadyFlowParams(κ, η, κh, nκh, u::Function, v::Function, grid::TwoDGrid)
   x, y = gridpoints(grid)
-  ugrid = u.(x, y)
-  vgrid = v.(x, y)
-  
-  return ConstDiffSteadyFlowParams2D(η, κ, κh, nκh, ugrid, vgrid)
+
+  return ConstDiffSteadyFlowParams2D(η, κ, κh, nκh, u.(x, y), v.(x, y))
 end
 
-ConstDiffSteadyFlowParams(η, κ, u, v, grid::TwoDGrid) = ConstDiffSteadyFlowParams(η, κ, 0η, 0, u, v, grid)
+ConstDiffSteadyFlowParams(η, κ, u, v, grid::TwoDGrid) =
+  σConstDiffSteadyFlowParams(κ, η, 0κ, 0, u, v, grid)
 
 function ConstDiffSteadyFlowParams(η, κ, ι, κh, nκh, u::Function, v::Function, w::Function, grid::ThreeDGrid)
   x, y, z = gridpoints(grid)
-  ugrid = u.(x, y, z)
-  vgrid = v.(x, y, z)
-  wgrid = w.(x, y, z)
    
-  return ConstDiffSteadyFlowParams3D(η, κ, ι, κh, nκh, ugrid, vgrid, wgrid)
+  return ConstDiffSteadyFlowParams3D(η, κ, ι, κh, nκh, u.(x, y, z), v.(x, y, z), w.(x, y, z))
  end
  
- ConstDiffSteadyFlowParams(η, κ, ι, u, v, w, grid::ThreeDGrid) = ConstDiffSteadyFlowParams(η, κ, ι, 0η, 0, u, v, w, grid)
+ ConstDiffSteadyFlowParams(κ, η, ι, u, v, w, grid::ThreeDGrid) =
+  ConstDiffSteadyFlowParams(κ, η, ι, 0κ, 0, u, v, w, grid)
 
 """
     struct ConstDiffTurbulentFlowParams{T} <: AbstractTurbulentFlowParams
 
-A struct containing the parameters for a constant diffusivity problem with flow obtained
-from a `GeophysicalFlows.MultiLayerQG` problem.
+A container for the parameters of a constant diffusivity problem with flow obtained
+from a `GeophysicalFlows.MultiLayerQG` problem. Includes:
 
 $(TYPEDFIELDS)
 """
 struct ConstDiffTurbulentFlowParams{T} <: AbstractTurbulentFlowParams
-  "isotropic horizontal diffusivity coefficient"
-                    η :: T
-  "isotropic vertical diffusivity coefficient"
+  "``x``-diffusivity coefficient"
                     κ :: T
+  "``y``-diffusivity coefficient"
+                    η :: T
   "isotropic hyperdiffusivity coefficient"
                    κh :: T
   "isotropic hyperdiffusivity order"  
@@ -446,17 +454,17 @@ struct ConstDiffTurbulentFlowParams{T} <: AbstractTurbulentFlowParams
 end
 
 """
-    ConstDiffTurbulentFlowParams(η, κ, tracer_release_time, MQGprob)
+    ConstDiffTurbulentFlowParams(κ, η, tracer_release_time, MQGprob)
 
 Return the parameters `params` for a constant diffusivity problem with flow obtained
 from a `GeophysicalFlows.MultiLayerQG` problem.
 """
-function ConstDiffTurbulentFlowParams(η, κ, tracer_release_time, MQGprob)
+function ConstDiffTurbulentFlowParams(κ, η, tracer_release_time, MQGprob)
   nlayers = numberoflayers(MQGprob.params)
   
   MultiLayerQG.updatevars!(MQGprob)
 
-  return ConstDiffTurbulentFlowParams(η, κ, 0η, 0, nlayers, tracer_release_time, MQGprob)
+  return ConstDiffTurbulentFlowParams(κ, η, 0κ, 0, nlayers, tracer_release_time, MQGprob)
 end
 
 # --
@@ -477,14 +485,16 @@ end
 
 function Equation(dev, params::ConstDiffTimeVaryingFlowParams2D, grid::TwoDGrid)
   L = zeros(dev, eltype(grid), (grid.nkr, grid.nl))
-  @. L = - params.η * grid.kr^2 - params.κ * grid.l^2 - params.κh * grid.Krsq^params.nκh
+  @. L = - params.κ * grid.kr^2 - params.η * grid.l^2
+         - params.κh * grid.Krsq^params.nκh
   
   return FourierFlows.Equation(L, calcN!, grid)
 end
 
 function Equation(dev, params::ConstDiffTimeVaryingFlowParams3D, grid::ThreeDGrid)
   L = zeros(dev, eltype(grid), (grid.nkr, grid.nl, grid.nm))
-  @. L = - params.η * grid.kr^2 - params.κ * grid.l^2 - params.ι * grid.m^2 - params.κh * grid.Krsq^params.nκh
+  @. L = - params.κ * grid.kr^2 - params.η * grid.l^2 - params.ι * grid.m^2
+         - params.κh * grid.Krsq^params.nκh
   
   return FourierFlows.Equation(L, calcN!, grid)
 end
@@ -498,14 +508,14 @@ end
 
 function Equation(dev, params::ConstDiffSteadyFlowParams2D, grid::TwoDGrid)
   L = zeros(dev, eltype(grid), (grid.nkr, grid.nl))
-  @. L = - params.η * grid.kr^2 - params.κ * grid.l^2 - params.κh * grid.Krsq^params.nκh
+  @. L = - params.κ * grid.kr^2 - params.η * grid.l^2 - params.κh * grid.Krsq^params.nκh
   
   return FourierFlows.Equation(L, calcN_steadyflow!, grid)
 end
 
 function Equation(dev, params::ConstDiffSteadyFlowParams3D, grid::ThreeDGrid)
   L = zeros(dev, eltype(grid), (grid.nkr, grid.nl, grid.nm))
-  @. L = - params.η * grid.kr^2 - params.κ * grid.l^2 - params.ι * grid.m^2 - params.κh * grid.Krsq^params.nκh
+  @. L = - params.κ * grid.kr^2 - params.η * grid.l^2 - params.ι * grid.m^2 - params.κh * grid.Krsq^params.nκh
   
   return FourierFlows.Equation(L, calcN_steadyflow!, grid)
 end
@@ -514,7 +524,7 @@ function Equation(dev, params::ConstDiffTurbulentFlowParams, grid)
   L = zeros(dev, eltype(grid), (grid.nkr, grid.nl, params.nlayers))
 
   for j in 1:params.nlayers
-      @. L[:, :, j] = - params.η * grid.kr^2 - params.κ * grid.l^2 - params.κh * grid.Krsq^params.nκh
+      @. L[:, :, j] = - params.κ * grid.kr^2 - params.η * grid.l^2 - params.κh * grid.Krsq^params.nκh
   end
 
   return FourierFlows.Equation(L, calcN_turbulentflow!, grid)
@@ -527,7 +537,7 @@ end
 """
     struct Vars1D{Aphys, Atrans} <: AbstractVars
 
-The variables for a 1D `TracerAdvectionDiffussion` problem.
+The variables of a 1D `TracerAdvectionDiffussion` problem.
 
 $(FIELDS)
 """
@@ -545,7 +555,7 @@ end
 """
     struct Vars2D{Aphys, Atrans} <: AbstractVars
 
-The variables for a 2D `TracerAdvectionDiffussion` problem.
+The variables of a 2D `TracerAdvectionDiffussion` problem.
 
 $(FIELDS)
 """
@@ -567,7 +577,7 @@ end
 """
     struct Vars3D{Aphys, Atrans} <: AbstractVars
 
-The variables for a 3D `TracerAdvectionDiffussion` problem.
+The variables of a 3D `TracerAdvectionDiffussion` problem.
 
 $(FIELDS)
 """
@@ -645,8 +655,9 @@ function calcN!(N, sol, t, clock, vars, params::AbstractTimeVaryingFlowParams, g
 
   ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
 
-  x = grid.x
-  @. vars.cx = -params.u(x, clock.t) * vars.cx # copies over vars.cx so vars.cx = N in physical space
+  # store N (in physical space) into vars.cx
+  @. vars.cx = - params.u(grid.x, clock.t) * vars.cx
+
   mul!(N, grid.rfftplan, vars.cx)
   
   return nothing
@@ -660,7 +671,11 @@ function calcN!(N, sol, t, clock, vars, params::AbstractTimeVaryingFlowParams, g
   ldiv!(vars.cy, grid.rfftplan, vars.cyh) # destroys vars.cyh when using fftw
 
   x, y = gridpoints(grid)
-  @. vars.cx = -params.u(x, y, clock.t) * vars.cx - params.v(x, y, clock.t) * vars.cy # copies over vars.cx so vars.cx = N in physical space
+
+  # store N (in physical space) into vars.cx
+  @. vars.cx = - params.u(x, y, clock.t) * vars.cx
+               - params.v(x, y, clock.t) * vars.cy
+
   mul!(N, grid.rfftplan, vars.cx)
   
   return nothing
@@ -673,14 +688,19 @@ function calcN!(N, sol, t, clock, vars, params::AbstractTimeVaryingFlowParams, g
 
   ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
   ldiv!(vars.cy, grid.rfftplan, vars.cyh) # destroys vars.cyh when using fftw
-  ldiv!(vars.cz, grid.rfftplan, vars.czh) # destroys vars.cyh when using fftw
+  ldiv!(vars.cz, grid.rfftplan, vars.czh) # destroys vars.czh when using fftw
 
   x, y, z = gridpoints(grid)
-  @. vars.cx = -params.u(x, y, z, clock.t) * vars.cx - params.v(x, y, z, clock.t) * vars.cy - params.w(x, y, z, clock.t) * vars.cz # copies over vars.cx so vars.cx = N in physical space
+
+  # store N (in physical space) into vars.cx
+  @. vars.cx = - params.u(x, y, z, clock.t) * vars.cx
+               - params.v(x, y, z, clock.t) * vars.cy
+               - params.w(x, y, z, clock.t) * vars.cz
+
   mul!(N, grid.rfftplan, vars.cx)
   
   return nothing
-  end
+end
 
 
 """
@@ -693,7 +713,8 @@ function calcN_steadyflow!(N, sol, t, clock, vars, params::AbstractSteadyFlowPar
 
   ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
 
-  @. vars.cx = -params.u * vars.cx # copies over vars.cx so vars.cx = N in physical space
+  # store N (in physical space) into vars.cx
+  @. vars.cx = -params.u * vars.cx
   mul!(N, grid.rfftplan, vars.cx)
   
   return nothing
@@ -706,7 +727,9 @@ function calcN_steadyflow!(N, sol, t, clock, vars, params::AbstractSteadyFlowPar
   ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
   ldiv!(vars.cy, grid.rfftplan, vars.cyh) # destroys vars.cyh when using fftw
 
-  @. vars.cx = -params.u * vars.cx - params.v * vars.cy # copies over vars.cx so vars.cx = N in physical space
+  # store N (in physical space) into vars.cx
+  @. vars.cx = -params.u * vars.cx - params.v * vars.cy
+
   mul!(N, grid.rfftplan, vars.cx)
   
   return nothing
@@ -721,7 +744,9 @@ function calcN_steadyflow!(N, sol, t, clock, vars, params::AbstractSteadyFlowPar
   ldiv!(vars.cy, grid.rfftplan, vars.cyh) # destroys vars.cyh when using fftw
   ldiv!(vars.cz, grid.rfftplan, vars.czh) # destroys vars.cyh when using fftw
 
-  @. vars.cx = -params.u * vars.cx - params.v * vars.cy - params.w * vars.cz # copies over vars.cx so vars.cx = N in physical space
+  # store N (in physical space) into vars.cx
+  @. vars.cx = -params.u * vars.cx - params.v * vars.cy - params.w * vars.cz
+
   mul!(N, grid.rfftplan, vars.cx)
   
   return nothing
@@ -742,7 +767,9 @@ function calcN_turbulentflow!(N, sol, t, clock, vars, params::AbstractTurbulentF
   u = @. params.MQGprob.vars.u + params.MQGprob.params.U
   v = params.MQGprob.vars.v
 
-  @. vars.cx = - u * vars.cx - v * vars.cy # copies over vars.cx so vars.cx = N in physical space
+  # store N (in physical space) into vars.cx
+  @. vars.cx = - u * vars.cx - v * vars.cy
+  
   fwdtransform!(N, vars.cx, params.MQGprob.params)
 
   return nothing

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -260,11 +260,11 @@ $(TYPEDFIELDS)
 """
 struct ConstDiffTimeVaryingFlowParams2D{T} <: AbstractTimeVaryingFlowParams
   "``x``-diffusivity coefficient"
-      κ :: T
+       κ :: T
   "``y``-diffusivity coefficient"
-      η :: T
+       η :: T
   "isotropic hyperdiffusivity coefficient"
-    κh :: T
+     κh :: T
   "isotropic hyperdiffusivity order"  
     nκh :: Int
   "function returning the ``x``-component of advecting flow"
@@ -289,7 +289,7 @@ struct ConstDiffTimeVaryingFlowParams3D{T} <: AbstractTimeVaryingFlowParams
   "``z``-diffusivity coefficient"
       ι :: T
   "isotropic hyperdiffusivity coefficient"
-    κh :: T
+     κh :: T
   "isotropic hyperdiffusivity order"  
     nκh :: Int
   "function returning the ``x``-component of advecting flow"

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -595,10 +595,10 @@ end
 Return the variables `vars` for a constant diffusivity problem on `grid` and device `dev`.
 """
 function Vars(::Dev, grid::OneDGrid; T=Float64) where Dev
-    @devzeros Dev T (grid.nx) c cx
-    @devzeros Dev Complex{T} (grid.nkr) ch cxh
+  @devzeros Dev T (grid.nx) c cx
+  @devzeros Dev Complex{T} (grid.nkr) ch cxh
     
-    return Vars1D(c, cx, ch, cxh)
+  return Vars1D(c, cx, ch, cxh)
 end
 
 function Vars(::Dev, grid::TwoDGrid; T=Float64) where Dev
@@ -609,11 +609,11 @@ function Vars(::Dev, grid::TwoDGrid; T=Float64) where Dev
 end
 
 function Vars(::Dev, grid::ThreeDGrid; T=Float64) where Dev
-    @devzeros Dev T (grid.nx, grid.ny, grid.nz) c cx cy cz
-    @devzeros Dev Complex{T} (grid.nkr, grid.nl, grid.nm) ch cxh cyh czh
+  @devzeros Dev T (grid.nx, grid.ny, grid.nz) c cx cy cz
+  @devzeros Dev Complex{T} (grid.nkr, grid.nl, grid.nm) ch cxh cyh czh
     
-    return Vars3D(c, cx, cy, cz, ch, cxh, cyh, czh)
-  end
+  return Vars3D(c, cx, cy, cz, ch, cxh, cyh, czh)
+end
 
 function Vars(dev::Dev, grid::AbstractGrid{T}, MQGprob::FourierFlows.Problem) where {Dev, T}
   nlayers = numberoflayers(MQGprob.params)
@@ -668,7 +668,7 @@ end
 function calcN!(N, sol, t, clock, vars, params::AbstractTimeVaryingFlowParams, grid::ThreeDGrid)
     @. vars.cxh = im * grid.kr * sol
     @. vars.cyh = im * grid.l  * sol
-    @. vars.cyh = im * grid.m  * sol
+    @. vars.czh = im * grid.m  * sol
   
     ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
     ldiv!(vars.cy, grid.rfftplan, vars.cyh) # destroys vars.cyh when using fftw

--- a/src/traceradvectiondiffusion.jl
+++ b/src/traceradvectiondiffusion.jl
@@ -243,7 +243,7 @@ struct ConstDiffTimeVaryingFlowParams1D{T} <: AbstractTimeVaryingFlowParams
   "diffusivity coefficient"
       κ :: T
   "hyperdiffusivity coefficient"
-    κh :: T
+     κh :: T
   "hyperdiffusivity order"  
     nκh :: Int
   "function returning the ``x``-component of advecting flow"
@@ -260,9 +260,9 @@ $(TYPEDFIELDS)
 """
 struct ConstDiffTimeVaryingFlowParams2D{T} <: AbstractTimeVaryingFlowParams
   "``x``-diffusivity coefficient"
-       κ :: T
+      κ :: T
   "``y``-diffusivity coefficient"
-       η :: T
+      η :: T
   "isotropic hyperdiffusivity coefficient"
      κh :: T
   "isotropic hyperdiffusivity order"  
@@ -324,8 +324,7 @@ ConstDiffTimeVaryingFlowParams(κ, η, ι, u, v, w) = ConstDiffTimeVaryingFlowPa
 """
     struct ConstDiffSteadyFlowParams1D{T} <: AbstractSteadyFlowParams
 
-A container forthe parameters of aa constant diffusivity problem with steady flow in one dimensions.
-Includes:
+The parameters of a constant diffusivity problem with steady flow in one dimension.
 
 $(TYPEDFIELDS)
 """
@@ -343,8 +342,7 @@ end
 """
     struct ConstDiffSteadyFlowParams2D{T} <: AbstractSteadyFlowParams
 
-A container for the parameters for a constant diffusivity problem with steady flow in two dimensions.
-Includes:
+The parameters for a constant diffusivity problem with steady flow in two dimensions.
 
 $(TYPEDFIELDS)
 """
@@ -366,8 +364,7 @@ end
 """
     struct ConstDiffSteadyFlowParams3D{T} <: AbstractSteadyFlowParams
 
-A container for the parameters for a constant diffusivity problem with steady flow in three dimensions.
-Includes:
+The parameters for a constant diffusivity problem with steady flow in three dimensions.
 
 $(TYPEDFIELDS)
 """
@@ -431,8 +428,8 @@ function ConstDiffSteadyFlowParams(κ, η, ι, κh, nκh, u::Function, v::Functi
 """
     struct ConstDiffTurbulentFlowParams{T} <: AbstractTurbulentFlowParams
 
-A container for the parameters of a constant diffusivity problem with flow obtained
-from a `GeophysicalFlows.MultiLayerQG` problem. Includes:
+The parameters of a constant diffusivity problem with flow obtained from a
+`GeophysicalFlows.MultiLayerQG` problem.
 
 $(TYPEDFIELDS)
 """
@@ -671,8 +668,7 @@ function calcN!(N, sol, t, clock, vars, params::AbstractTimeVaryingFlowParams, g
   x, y = gridpoints(grid)
 
   # store N (in physical space) into vars.cx
-  @. vars.cx = - params.u(x, y, clock.t) * vars.cx
-               - params.v(x, y, clock.t) * vars.cy
+  @. vars.cx = - params.u(x, y, clock.t) * vars.cx - params.v(x, y, clock.t) * vars.cy
 
   mul!(N, grid.rfftplan, vars.cx)
   
@@ -691,9 +687,7 @@ function calcN!(N, sol, t, clock, vars, params::AbstractTimeVaryingFlowParams, g
   x, y, z = gridpoints(grid)
 
   # store N (in physical space) into vars.cx
-  @. vars.cx = - params.u(x, y, z, clock.t) * vars.cx
-               - params.v(x, y, z, clock.t) * vars.cy
-               - params.w(x, y, z, clock.t) * vars.cz
+  @. vars.cx = - params.u(x, y, z, clock.t) * vars.cx - params.v(x, y, z, clock.t) * vars.cy - params.w(x, y, z, clock.t) * vars.cz
 
   mul!(N, grid.rfftplan, vars.cx)
   
@@ -712,7 +706,7 @@ function calcN_steadyflow!(N, sol, t, clock, vars, params::AbstractSteadyFlowPar
   ldiv!(vars.cx, grid.rfftplan, vars.cxh) # destroys vars.cxh when using fftw
 
   # store N (in physical space) into vars.cx
-  @. vars.cx = -params.u * vars.cx
+  @. vars.cx = - params.u * vars.cx
   mul!(N, grid.rfftplan, vars.cx)
   
   return nothing
@@ -726,7 +720,7 @@ function calcN_steadyflow!(N, sol, t, clock, vars, params::AbstractSteadyFlowPar
   ldiv!(vars.cy, grid.rfftplan, vars.cyh) # destroys vars.cyh when using fftw
 
   # store N (in physical space) into vars.cx
-  @. vars.cx = -params.u * vars.cx - params.v * vars.cy
+  @. vars.cx = - params.u * vars.cx - params.v * vars.cy
 
   mul!(N, grid.rfftplan, vars.cx)
   
@@ -743,7 +737,7 @@ function calcN_steadyflow!(N, sol, t, clock, vars, params::AbstractSteadyFlowPar
   ldiv!(vars.cz, grid.rfftplan, vars.czh) # destroys vars.cyh when using fftw
 
   # store N (in physical space) into vars.cx
-  @. vars.cx = -params.u * vars.cx - params.v * vars.cy - params.w * vars.cz
+  @. vars.cx = - params.u * vars.cx - params.v * vars.cy - params.w * vars.cz
 
   mul!(N, grid.rfftplan, vars.cx)
   

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,17 +29,25 @@ for dev in devices
     dt, tfinal  = 0.002, 0.1
     @test test_timedependentvel1D(stepper, dt, tfinal, dev)
     dt, nsteps  = 1e-2, 40
-    @test test_constvel(stepper, dt, nsteps, dev)
+    @test test_constvel2D(stepper, dt, nsteps, dev)
     dt, tfinal  = 0.002, 0.1
-    @test test_timedependentvel(stepper, dt, tfinal, dev)
+    @test test_timedependentvel2D(stepper, dt, tfinal, dev)
+    dt, nsteps  = 1e-2, 40
+    @test test_constvel3D(stepper, dt, nsteps, dev)
+    dt, tfinal  = 0.002, 0.1
+    @test test_timedependentvel3D(stepper, dt, tfinal, dev)
     dt, tfinal  = 0.005, 0.1
     @test test_diffusion1D(stepper, dt, tfinal, dev; steadyflow=true)
     dt, tfinal  = 0.005, 0.1
     @test test_diffusion1D(stepper, dt, tfinal, dev; steadyflow=false)
     dt, tfinal  = 0.005, 0.1
-    @test test_diffusion(stepper, dt, tfinal, dev; steadyflow=true)
+    @test test_diffusion2D(stepper, dt, tfinal, dev; steadyflow=true)
     dt, tfinal  = 0.005, 0.1
-    @test test_diffusion(stepper, dt, tfinal, dev; steadyflow=false)
+    @test test_diffusion2D(stepper, dt, tfinal, dev; steadyflow=false)
+    dt, tfinal  = 0.005, 0.1
+    @test test_diffusion3D(stepper, dt, tfinal, dev; steadyflow=true)
+    dt, tfinal  = 0.005, 0.1
+    @test test_diffusion3D(stepper, dt, tfinal, dev; steadyflow=false)
     dt, tfinal  = 0.005, 0.1
     @test test_diffusion_multilayerqg(stepper, dt, tfinal, dev)
     dt, tfinal  = 0.005, 0.1

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -13,7 +13,7 @@ function test_constvel1D(stepper, dt, nsteps, dev::Device=CPU())
   advecting_flow = OneDAdvectingFlow(; u)
 
   prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper)
-  sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+  sol, vs, pr, gr = prob.sol, prob.vars, prob.params, prob.grid
   x = gridpoints(gr)
 
   σ = 0.1
@@ -52,7 +52,7 @@ function test_timedependentvel1D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 
   advecting_flow = OneDAdvectingFlow(; u, steadyflow = false)
 
   prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper)
-  sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+  sol, vs, pr, gr = prob.sol, prob.vars, prob.params, prob.grid
   x = gridpoints(gr)
 
   σ = 0.2
@@ -85,7 +85,7 @@ function test_constvel2D(stepper, dt, nsteps, dev::Device=CPU())
   advecting_flow = TwoDAdvectingFlow(; u, v)
 
   prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper)
-  sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+  sol, vs, pr, gr = prob.sol, prob.vars, prob.params, prob.grid
 
   x, y = gridpoints(gr)
 
@@ -114,7 +114,6 @@ Advect a gaussian concentration `c0(x, y, t)` with a time-varying velocity flow
 state with `cfinal = c0(x - uvel * tfinal, y)`.
 """
 function test_timedependentvel2D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 0.5, αv = 0.5)
-  
   nx, Lx = 128, 2π
   nsteps = round(Int, tfinal/dt)
   
@@ -127,7 +126,7 @@ function test_timedependentvel2D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 
   advecting_flow = TwoDAdvectingFlow(; u, v, steadyflow = false)
 
   prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper)
-  sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+  sol, vs, pr, gr = prob.sol, prob.vars, prob.params, prob.grid
   x, y = gridpoints(gr)
 
   σ = 0.2
@@ -154,16 +153,15 @@ Advect a gaussian concentration `c0(x, y, t)` with a constant velocity flow
 `cfinal = c0(x - uvel * tfinal, y - vvel * tfinal, z - wvel * tfinal)`.
 """
 function test_constvel3D(stepper, dt, nsteps, dev::Device=CPU())
-
   nx, Lx = 128, 2π
-  uvel, vvel, wvel = 0.2, 0.1, 0.15
+  uvel, vvel, wvel = 0.2, 0.1, 0.05
   u(x, y, z) = uvel
   v(x, y, z) = vvel
   w(x, y, z) = wvel
   advecting_flow = ThreeDAdvectingFlow(; u, v, w)
 
   prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper)
-  sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+  sol, vs, pr, gr = prob.sol, prob.vars, prob.params, prob.grid
 
   x, y, z = gridpoints(gr)
 
@@ -192,7 +190,6 @@ Advect a gaussian concentration `c0(x, y, z, t)` with a time-varying velocity fl
 compares the final state with `cfinal = c0(x - uvel * tfinal, y, z - wvel * tfinal)`.
 """
 function test_timedependentvel3D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 0.5, αv = 0.5, wvel = 0.5)
-  
   nx, Lx = 128, 2π
   nsteps = round(Int, tfinal/dt)
   
@@ -206,7 +203,8 @@ function test_timedependentvel3D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 
   advecting_flow = ThreeDAdvectingFlow(; u, v, w, steadyflow = false)
 
   prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper)
-  sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+  sol, vs, pr, gr = prob.sol, prob.vars, prob.params, prob.grid
+  
   x, y, z = gridpoints(gr)
 
   σ = 0.2
@@ -246,7 +244,7 @@ function test_diffusion1D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
   advecting_flow = OneDAdvectingFlow(; steadyflow)
 
   prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ, dt, stepper)
-  sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+  sol, vs, pr, gr = prob.sol, prob.vars, prob.params, prob.grid
   x = gridpoints(gr)
   
   c0ampl, σ₀ = 0.1, 0.1
@@ -283,7 +281,7 @@ function test_diffusion2D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
 
   advecting_flow = TwoDAdvectingFlow(; steadyflow)
   prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ, dt, stepper)
-  sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+  sol, vs, pr, gr = prob.sol, prob.vars, prob.params, prob.grid
   x, y = gridpoints(gr)
 
   c0ampl, σ = 0.1, 0.1
@@ -336,7 +334,7 @@ function test_diffusion_multilayerqg(stepper, dt, tfinal, dev::Device=CPU())
   end
 
   ADprob = TracerAdvectionDiffusion.Problem(dev, MQGprob; κ, stepper, tracer_release_time)
-  sol, cl, vs, pr, gr = ADprob.sol, ADprob.clock, ADprob.vars, ADprob.params, ADprob.grid
+  sol, vs, pr, gr = ADprob.sol, ADprob.vars, ADprob.params, ADprob.grid
   x, y = gridpoints(gr)
 
   c0ampl, σ = 0.1, 0.1
@@ -374,7 +372,7 @@ function test_diffusion3D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
 
   advecting_flow = ThreeDAdvectingFlow(; steadyflow)
   prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ, dt, stepper)
-  sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+  sol, vs, pr, gr = prob.sol, prob.vars, prob.params, prob.grid
   x, y, z = gridpoints(gr)
 
   c0ampl, σ = 0.1, 0.1
@@ -416,7 +414,6 @@ function test_hyperdiffusion(stepper, dt, tfinal, dev::Device=CPU(); steadyflow 
   gr = TwoDGrid(dev, nx, Lx)
   x, y = gridpoints(gr)
 
-  #u, v = zero(x), zero(x) #0*x, 0*x
   u(x, y) = 0.0
   v(x, y) = 0.0
 

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -156,7 +156,7 @@ Advect a gaussian concentration `c0(x, y, t)` with a constant velocity flow
 function test_constvel3D(stepper, dt, nsteps, dev::Device=CPU())
 
   nx, Lx = 128, 2π
-  uvel, vvel, wvel = 0.2, 0.1, 0.1
+  uvel, vvel, wvel = 0.2, 0.1, 0.15
   u(x, y, z) = uvel
   v(x, y, z) = vvel
   w(x, y, z) = wvel
@@ -188,8 +188,8 @@ end
     test_timedependenttvel3D(; kwargs...)
 
 Advect a gaussian concentration `c0(x, y, z, t)` with a time-varying velocity flow
-`u(x, y, z, t) = uvel`, `v(x, y, z, t) = vvel * sign(-t + tfinal/2)` and `w(x, y, z, t) = wvel` and compares the final
-state with `cfinal = c0(x - uvel * tfinal, y, z - wvel)`.
+`u(x, y, z, t) = uvel`, `v(x, y, z, t) = vvel * sign(-t + tfinal/2)` and `w(x, y, z, t) = wvel` and
+compares the final state with `cfinal = c0(x - uvel * tfinal, y, z - wvel * tfinal)`.
 """
 function test_timedependentvel3D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 0.5, αv = 0.5, wvel = 0.5)
   
@@ -353,9 +353,10 @@ function test_diffusion_multilayerqg(stepper, dt, tfinal, dev::Device=CPU())
   TracerAdvectionDiffusion.updatevars!(ADprob)
 
   # Compare to analytic solution
-  return isapprox(cfinal, vs.c[:, :, 1], rtol = gr.nx*gr.ny*nsteps*1e-12)  &&
+  return isapprox(cfinal, vs.c[:, :, 1], rtol = gr.nx*gr.ny*nsteps*1e-12) &&
          isapprox(cfinal, vs.c[:, :, 2], rtol = gr.nx*gr.ny*nsteps*1e-12)
 end
+
 """
     test_diffusion3D(; kwargs...)
 
@@ -404,11 +405,10 @@ function test_hyperdiffusion(stepper, dt, tfinal, dev::Device=CPU(); steadyflow 
 
    nx = 128
    Lx = 2π
-    κ = 0.0   # no diffusivity
-    η = κ     # no diffusivity
-   κh = 0.01  # hyperdiffusivity coeff
-  nκh = 1     # nκh=1 converts hyperdiffusivity to plain diffusivity
-              # so we can compare with the analytic solution of heat equation
+    κ = η = 0.0  # no diffusivity
+   κh = 0.01     # hyperdiffusivity coeff
+  nκh = 1        # nκh=1 converts hyperdiffusivity to plain diffusivity
+                 # so we can compare with the analytic solution of heat equation
 
   nsteps = round(Int, tfinal/dt)
 

--- a/test/test_traceradvectiondiffusion.jl
+++ b/test/test_traceradvectiondiffusion.jl
@@ -70,13 +70,13 @@ function test_timedependentvel1D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 
 end
 
 """
-    test_constvel(; kwargs...)
+    test_constvel2D(; kwargs...)
 
 Advect a gaussian concentration `c0(x, y, t)` with a constant velocity flow
 `u(x, y) = uvel` and `v(x, y) = vvel` and compares the final state with
 `cfinal = c0(x - uvel * tfinal, y - vvel * tfinal)`.
 """
-function test_constvel(stepper, dt, nsteps, dev::Device=CPU())
+function test_constvel2D(stepper, dt, nsteps, dev::Device=CPU())
 
   nx, Lx = 128, 2π
   uvel, vvel = 0.2, 0.1
@@ -107,13 +107,13 @@ end
 
 
 """
-    test_timedependenttvel(; kwargs...)
+    test_timedependenttvel2D(; kwargs...)
 
 Advect a gaussian concentration `c0(x, y, t)` with a time-varying velocity flow
 `u(x, y, t) = uvel` and `v(x, y, t) = vvel * sign(-t + tfinal/2)` and compares the final
 state with `cfinal = c0(x - uvel * tfinal, y)`.
 """
-function test_timedependentvel(stepper, dt, tfinal, dev::Device=CPU(); uvel = 0.5, αv = 0.5)
+function test_timedependentvel2D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 0.5, αv = 0.5)
   
   nx, Lx = 128, 2π
   nsteps = round(Int, tfinal/dt)
@@ -143,6 +143,86 @@ function test_timedependentvel(stepper, dt, tfinal, dev::Device=CPU(); uvel = 0.
   TracerAdvectionDiffusion.updatevars!(prob)
 
   return isapprox(cfinal, vs.c, rtol = gr.nx*gr.ny*nsteps*1e-12)
+end
+
+
+"""
+    test_constvel3D(; kwargs...)
+
+Advect a gaussian concentration `c0(x, y, t)` with a constant velocity flow
+`u(x, y, z) = uvel`, `v(x, y, z) = vvel` and `w(x, y, z) = wvel` and compares the final state with
+`cfinal = c0(x - uvel * tfinal, y - vvel * tfinal, z - wvel * tfinal)`.
+"""
+function test_constvel3D(stepper, dt, nsteps, dev::Device=CPU())
+
+  nx, Lx = 128, 2π
+  uvel, vvel, wvel = 0.2, 0.1, 0.1
+  u(x, y, z) = uvel
+  v(x, y, z) = vvel
+  w(x, y, z) = wvel
+  advecting_flow = ThreeDAdvectingFlow(; u, v, w)
+
+  prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper)
+  sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+
+  x, y, z = gridpoints(gr)
+
+  σ = 0.1
+  c0ampl = 0.1
+  c0func(x, y, z) = c0ampl * exp(-(x^2 + y^2 + z^2) / 2σ^2)
+
+  c0 = c0func.(x, y, z)
+  tfinal = nsteps * dt
+  cfinal = @. c0func(x - uvel * tfinal, y - vvel * tfinal, z - wvel * tfinal)
+
+  TracerAdvectionDiffusion.set_c!(prob, c0)
+
+  stepforward!(prob, nsteps)
+  TracerAdvectionDiffusion.updatevars!(prob)
+
+  return isapprox(cfinal, vs.c, rtol = gr.nx*gr.ny*gr.nz*nsteps*1e-12)
+end
+
+
+"""
+    test_timedependenttvel3D(; kwargs...)
+
+Advect a gaussian concentration `c0(x, y, z, t)` with a time-varying velocity flow
+`u(x, y, z, t) = uvel`, `v(x, y, z, t) = vvel * sign(-t + tfinal/2)` and `w(x, y, z, t) = wvel` and compares the final
+state with `cfinal = c0(x - uvel * tfinal, y, z - wvel)`.
+"""
+function test_timedependentvel3D(stepper, dt, tfinal, dev::Device=CPU(); uvel = 0.5, αv = 0.5, wvel = 0.5)
+  
+  nx, Lx = 128, 2π
+  nsteps = round(Int, tfinal/dt)
+  
+  if !isapprox(tfinal, nsteps*dt, rtol=rtol_traceradvectiondiffusion)
+    error("tfinal is not multiple of dt")
+  end
+  
+  u(x, y, z, t) = uvel
+  v(x, y, z, t) = αv * t + αv * dt/2
+  w(x, y, z, t) = wvel
+  advecting_flow = ThreeDAdvectingFlow(; u, v, w, steadyflow = false)
+
+  prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ=0.0, dt, stepper)
+  sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+  x, y, z = gridpoints(gr)
+
+  σ = 0.2
+  c0ampl = 0.1
+  c0func(x, y, z) = c0ampl * exp(-(x^2 + y^2 + z^2) / 2σ^2)
+
+  c0 = @. c0func(x, y, z)
+  tfinal = nsteps * dt
+  cfinal = @. c0func(x - uvel * tfinal, y - 0.5αv * tfinal^2, z - wvel * tfinal)
+
+  TracerAdvectionDiffusion.set_c!(prob, c0)
+
+  stepforward!(prob, nsteps)
+  TracerAdvectionDiffusion.updatevars!(prob)
+
+  return isapprox(cfinal, vs.c, rtol = gr.nx*gr.ny*gr.nz*nsteps*1e-12)
 end
 
 """
@@ -186,12 +266,12 @@ function test_diffusion1D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = t
 end
 
 """
-    test_diffusion(; kwargs...)
+    test_diffusion2D(; kwargs...)
 
 Diffuses a gaussian concentration c0(x, y, t) and compares the final state with
 the analytic solution of the heat equation, cfinal
 """
-function test_diffusion(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = true)
+function test_diffusion2D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = true)
 
   nx = 128
   Lx = 2π
@@ -276,6 +356,43 @@ function test_diffusion_multilayerqg(stepper, dt, tfinal, dev::Device=CPU())
   return isapprox(cfinal, vs.c[:, :, 1], rtol = gr.nx*gr.ny*nsteps*1e-12)  &&
          isapprox(cfinal, vs.c[:, :, 2], rtol = gr.nx*gr.ny*nsteps*1e-12)
 end
+"""
+    test_diffusion3D(; kwargs...)
+
+Diffuses a gaussian concentration c0(x, y, z, t) and compares the final state with
+the analytic solution of the heat equation, cfinal
+"""
+function test_diffusion3D(stepper, dt, tfinal, dev::Device=CPU(); steadyflow = true)
+
+    nx = 128
+    Lx = 2π
+     κ = 0.01
+    nsteps = round(Int, tfinal/dt)
+  
+    if !isapprox(tfinal, nsteps*dt, rtol=rtol_traceradvectiondiffusion)
+      error("tfinal is not multiple of dt")
+    end
+  
+    advecting_flow = ThreeDAdvectingFlow(; steadyflow)
+    prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx, Lx, κ, dt, stepper)
+    sol, cl, vs, pr, gr = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
+    x, y, z = gridpoints(gr)
+  
+    c0ampl, σ = 0.1, 0.1
+    c0func(x, y, z) = c0ampl * exp(-(x^2 + y^2 + z^2) / 2σ^2)
+  
+    c0 = @. c0func(x, y, z)
+    tfinal = nsteps * dt
+    σt = sqrt(2κ * tfinal + σ^2)
+    cfinal = @. c0ampl * (σ^3 / σt^3) * exp(-(x^2 + y^2 + z^2) / 2σt^2)
+  
+    TracerAdvectionDiffusion.set_c!(prob, c0)
+  
+    stepforward!(prob, nsteps)
+    TracerAdvectionDiffusion.updatevars!(prob)
+  
+    return isapprox(cfinal, vs.c, rtol=gr.nx*gr.ny*gr.nz*nsteps*1e-12)
+  end
 
 """
     test_hyperdiffusion(; kwargs...)


### PR DESCRIPTION
This PR adds functionality to advect-diffuse a passive tracer in a 3D domain. It adds a new method to `TracerAdvectionDiffusion.Problem` that takes in a  flow of type `ThreeDAdvectingFlow`. The setup of the `Problem` is the same as for the one and two dimensional methods already there. 

I have written some tests but have not written an example. With the setup and simulation being so similar to the 1D and 2D cases do you think it necessary to have an example for the 3D advection-diffusion? Happy to write one just thought would see what you thought first.

I also have not updated any documentation files yet (e.g. the manual) but can do so if you think everything looks to be performing ok.