### PR TITLE
Use `Makie.jl` for plotting instead of `Plots.jl`

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,9 +3,7 @@ CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 Literate = "≥2.9.0"
-Plots = "≥ 1.10.1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,11 +4,6 @@ using
   CairoMakie,   # to not capture precompilation output
   PassiveTracerFlows
 
-# Gotta set this environment variable when using the GR run-time on Travis CI.
-# This happens as examples will use Plots.jl to make plots and movies.
-# See: https://github.com/jheinen/GR.jl/issues/278
-ENV["GKSwstype"] = "100"
-
 #####
 ##### Generate examples
 #####

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,7 @@
 using
   Documenter,
   Literate,
-  Plots,   # to not capture precompilation output
-  CairoMakie,
+  CairoMakie,   # to not capture precompilation output
   PassiveTracerFlows
 
 # Gotta set this environment variable when using the GR run-time on Travis CI.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,7 @@ using
   Documenter,
   Literate,
   Plots,   # to not capture precompilation output
+  CairoMakie,
   PassiveTracerFlows
 
 # Gotta set this environment variable when using the GR run-time on Travis CI.

--- a/examples/cellularflow.jl
+++ b/examples/cellularflow.jl
@@ -134,3 +134,5 @@ record(fig, "cellularflow_advection-diffusion.mp4", frames, framerate = 12) do j
   stepforward!(prob, nsubs)
   TracerAdvectionDiffusion.updatevars!(prob)
 end
+
+# ![](cellularflow_advection-diffusion.mp4)

--- a/examples/onedim_gaussiandiffusion.jl
+++ b/examples/onedim_gaussiandiffusion.jl
@@ -109,7 +109,7 @@ x, Lx  = file["grid/x"], file["grid/Lx"]
 
 n = Observable(1)
 c_anim = @lift c[$n]
-title = @lift sprintf("concentration, t = %s", t[$n])
+title = @lift @sprintf("concentration, t = %s", t[$n])
 
 fig = Figure(resolution = (600, 600))
 ax = Axis(fig[1, 1],

--- a/examples/onedim_gaussiandiffusion.jl
+++ b/examples/onedim_gaussiandiffusion.jl
@@ -38,7 +38,8 @@ L = 2π       # domain size
 nothing # hide
 
 # ## Flow
-# We set a constant background flow and pass this to `OneDAdvectingFlow` with `steadyflow = true` to indicate the flow is not time dependent.
+# We set a constant background flow and pass this to `OneDAdvectingFlow` with `steadyflow = true` to
+# indicate the flow is not time dependent.
 u(x) = 0.05
 advecting_flow = OneDAdvectingFlow(; u, steadyflow = true)
 
@@ -47,7 +48,7 @@ advecting_flow = OneDAdvectingFlow(; u, steadyflow = true)
 prob = TracerAdvectionDiffusion.Problem(dev, advecting_flow; nx=n, Lx=L, κ, dt, stepper)
 nothing # hide
 
-# and define some shortcuts
+# and define some shortcuts.
 sol, clock, vars, params, grid = prob.sol, prob.clock, prob.vars, prob.params, prob.grid
 x = grid.x
 
@@ -105,7 +106,7 @@ c = [file["snapshots/concentration/$i"] for i ∈ iterations]
 nothing # hide
 
 # Set up the plotting arguments and look at the initial concentration.
-x, Lx  = file["grid/x"], file["grid/Lx"]
+x, Lx = file["grid/x"], file["grid/Lx"]
 
 n = Observable(1)
 c_anim = @lift c[$n]
@@ -117,7 +118,7 @@ ax = Axis(fig[1, 1],
           ylabel = "c",
           limits = ((-Lx/2, Lx/2), (0, maximum(c[1]))))
 
-lines!(ax, x, c_anim)
+lines!(ax, x, c_anim; linewidth = 4)
 
 # Now, we create a movie of the tracer concentration being advected and diffused.
 

--- a/examples/onedim_gaussiandiffusion.jl
+++ b/examples/onedim_gaussiandiffusion.jl
@@ -128,4 +128,5 @@ record(fig, "1D_advection-diffusion.mp4", frames, framerate = 18) do i
 end
 
 nothing # hide
+
 # ![](1D_advection-diffusion.mp4)

--- a/examples/turbulent_advection-diffusion.jl
+++ b/examples/turbulent_advection-diffusion.jl
@@ -208,4 +208,5 @@ record(fig, "turbulentflow_advection-diffusion.mp4", frames, framerate = 18) do 
 end
 
 nothing # hide
+
 # ![](turbulentflow_advection-diffusion.mp4)

--- a/examples/turbulent_advection-diffusion.jl
+++ b/examples/turbulent_advection-diffusion.jl
@@ -5,7 +5,7 @@
 #
 # ## Install dependencies
 #
-# First let's make sure we have all the required packages installed
+# First let's make sure we have all the required packages installed.
 
 # ```julia
 # using Pkg
@@ -43,10 +43,10 @@ L = 2π                   # domain size
 
 nlayers = 2              # number of layers
 f₀, g = 1, 1             # Coriolis parameter and gravitational constant
- H = [0.2, 0.8]          # the rest depths of each layer
- ρ = [4.0, 5.0]          # the density of each layer
+H = [0.2, 0.8]           # the rest depths of each layer
+ρ = [4.0, 5.0]           # the density of each layer
 
- U = zeros(nlayers) # the imposed mean zonal flow in each layer
+ U = zeros(nlayers)      # the imposed mean zonal flow in each layer
  U[1] = 1.0
  U[2] = 0.0
 nothing # hide
@@ -55,14 +55,14 @@ nothing # hide
 MQGprob = MultiLayerQG.Problem(nlayers, dev;
                                nx=n, Lx=L, f₀, g, H, ρ, U, μ, β,
                                dt, stepper, aliased_fraction=0)
-grid = MQGprob.grid
-x, y = grid.x, grid.y
+
+nx, ny = MQGprob.grid.nx, MQGprob.grid.ny
 
 # Initial conditions                        
 seed!(1234) # reset of the random number generator for reproducibility
-q₀  = 1e-2 * ArrayType(dev)(randn((grid.nx, grid.ny, nlayers)))
+q₀  = 1e-2 * ArrayType(dev)(randn((nx, ny, nlayers)))
 q₀h = MQGprob.timestepper.filter .* rfft(q₀, (1, 2)) # apply rfft  only in dims=1, 2
-q₀  = irfft(q₀h, grid.nx, (1, 2))                    # apply irfft only in dims=1, 2
+q₀  = irfft(q₀h, nx, (1, 2))                         # apply irfft only in dims=1, 2
 
 MultiLayerQG.set_q!(MQGprob, q₀)
 nothing # hide
@@ -74,35 +74,35 @@ nothing # hide
 # as an argument to `TracerAdvectionDiffusion.Problem` which sets up an advection-diffusion problem
 # with same parameters where applicable. We also need to pass a value for the constant diffusivity `κ`,
 # the `stepper` used to step the problem forward and when we want the tracer released into the flow.
-# We will let the flow run up to `t = tracer_release_time` and then release the tracer and let it
+# We let the flow evolve up to `t = tracer_release_time` and then release the tracer and let it
 # evolve with the flow.
 
-κ = 0.002                        # Constant diffusivity
+κ = 0.002                        # constant diffusivity
 nsteps = 4000                    # total number of time-steps
 tracer_release_time = 25.0       # run flow for some time before releasing tracer
 
 ADprob = TracerAdvectionDiffusion.Problem(dev, MQGprob; κ, stepper, tracer_release_time)
 
+# Some shortcuts for the advection-diffusion problem:
+sol, clock, vars, params, grid = ADprob.sol, ADprob.clock, ADprob.vars, ADprob.params, ADprob.grid
+x, y = grid.x, grid.y
+
 # ## Initial condition for concentration in both layers
 #
-# We have a two layer system so we will advect-diffuse the tracer in both layers.
+# We have a two layer system so we advect-diffuse the tracer in both layers.
 # To do this we set the initial condition for tracer concetration as a Gaussian centered at the origin.
 # Then we create some shortcuts for the `TracerAdvectionDiffusion.Problem`.
-gaussian(x, y, σ) = exp(-(x^2 + y^2) / (2σ^2))
+gaussian(x, y, σ) = exp(-(x^2 + y^2) / 2σ^2)
 
 amplitude, spread = 10, 0.15
 c₀ = [amplitude * gaussian(x[i], y[j], spread) for j=1:grid.ny, i=1:grid.nx]
 
 TracerAdvectionDiffusion.set_c!(ADprob, c₀)
 
-# Shortcuts for advection-diffusion problem
-sol, clock, vars, params, grid = ADprob.sol, ADprob.clock, ADprob.vars, ADprob.params, ADprob.grid
-x, y = grid.x, grid.y
-
 # ## Saving output
 #
 # The parent package `FourierFlows.jl` provides the functionality to save the output from our simulation.
-# To do this we write a function `get_concentration` and pass this to the `Output` function along 
+# To do this we write a function `get_concentration` and pass this to the `Output` constructor along 
 # with the `TracerAdvectionDiffusion.Problem` and the name of the output file.
 
 function get_concentration(prob)
@@ -126,7 +126,7 @@ end
 output = Output(ADprob, "advection-diffusion.jld2",
                 (:concentration, get_concentration), (:streamfunction, get_streamfunction))
 
-# This saves information that we will use for plotting later on
+# This saves information that we will use for plotting later on.
 saveproblem(output)
 
 # ## Step the problem forward and save the output
@@ -155,7 +155,7 @@ end
 #
 # We now have output from our simulation saved in `advection-diffusion.jld2`.
 # As a demonstration, we load the JLD2 output and create a time series for the tracer
-# that has been advected-diffused in the lower layer of our fluid.
+# in the lower layer of our fluid along with the flow streamlines.
 
 # Create time series for the concentration and streamfunction in the bottom layer, `layer = 2`.
 file = jldopen(output.path)
@@ -169,9 +169,9 @@ c = [file["snapshots/concentration/$i"][:, :, layer] for i ∈ iterations]
 ψ = [file["snapshots/streamfunction/$i"][:, :, layer] for i ∈ iterations]
 nothing # hide
 
-# We normalize all streamfunctions to have maximum absolute value `amplitude / 5`.
+# We normalize all streamfunctions to have maximum absolute value 1.
 for i in 1:lastindex(ψ)
-  ψ[i] *= (amplitude / 5) / maximum(abs, ψ[i])
+  ψ[i] /= maximum(abs, ψ[i])
 end
 
 x,  y  = file["grid/x"],  file["grid/y"]
@@ -181,19 +181,22 @@ n = Observable(1)
 
 c_anim = @lift c[$n]
 ψ_anim = @lift ψ[$n]
-title = @lift @sprintf("concentration, t = %s", t[$n])
+title = @lift @sprintf("concentration, t = %.2f", t[$n])
 
-fig = Figure(resolution = (700, 700))
+fig = Figure(resolution = (600, 600))
 ax = Axis(fig[1, 1], 
-            xlabel = "x",
-            ylabel = "y",
-            aspect = 1,
-            title = title, 
-            limits = ((-Lx/2, Lx/2), (-Ly/2, Ly/2)))
+          xlabel = "x",
+          ylabel = "y",
+          aspect = 1,
+          title = title, 
+          limits = ((-Lx/2, Lx/2), (-Ly/2, Ly/2)))
 
-hm = heatmap!(ax, x, y, c_anim; colormap = :balance, colorrange = (-amplitude/5, amplitude/5))
-contour!(ax, x, y, ψ_anim; levels = 0.15:0.3:1.5, color = :grey, linestyle = :solid, alpha = 0.5)
-contour!(ax, x, y, ψ_anim; levels = -0.15:-0.3:-1.5, color = :grey, linestyle = :dash, alpha = 0.5)
+hm = heatmap!(ax, x, y, c_anim;
+              colormap = :balance, colorrange = (-1, 1))
+contour!(ax, x, y, ψ_anim;
+         levels = 0.1:0.2:1, color = :grey, linestyle = :solid)
+contour!(ax, x, y, ψ_anim;
+         levels = -0.1:-0.2:-1, color = (:grey, 0.8), linestyle = :dash)
 
 nothing # hide
 

--- a/examples/turbulent_advection-diffusion.jl
+++ b/examples/turbulent_advection-diffusion.jl
@@ -203,7 +203,7 @@ nothing # hide
 # Create a movie of the tracer with the streamlines.
 
 frames = 1:length(t)
-record(fig, "turbulentflow_advection-diffusion.mp4", frames, framerate = 18) do i
+record(fig, "turbulentflow_advection-diffusion.mp4", frames, framerate = 12) do i
     n[] = i
 end
 

--- a/examples/turbulent_advection-diffusion.jl
+++ b/examples/turbulent_advection-diffusion.jl
@@ -188,7 +188,7 @@ ax = Axis(fig[1, 1],
           xlabel = "x",
           ylabel = "y",
           aspect = 1,
-          title = title, 
+          title = title,
           limits = ((-Lx/2, Lx/2), (-Ly/2, Ly/2)))
 
 hm = heatmap!(ax, x, y, c_anim;


### PR DESCRIPTION
This PR changes the plotting and animations from `Plots.jl` to `Makie.jl`. I noticed that this transition has occurred in `FourierFlows.jl` and looks to be happening to `GeophysicalFlows.jl` as well (FourierFlows/GeophysicalFlows.jl#288).